### PR TITLE
Support observations with progTime and partTime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .settings
 **/*.iml
 **/*.ipr
+/itac-web/bin/

--- a/phase1-data/src/main/database/093_addvisitorsite.sql
+++ b/phase1-data/src/main/database/093_addvisitorsite.sql
@@ -1,4 +1,4 @@
-UPDATE schema_version SET version = 92;
+UPDATE schema_version SET version = 93;
 
 alter table v2_blueprints add column visitor_site varchar(40);
 update v2_blueprints set instrument='PHOENIX_GS' where instrument='PHOENIX';

--- a/phase1-data/src/main/database/094_add_prog_part_time.sql
+++ b/phase1-data/src/main/database/094_add_prog_part_time.sql
@@ -1,0 +1,6 @@
+UPDATE schema_version SET version = 94;
+
+alter table v2_observations add column prog_time_amount_value numeric not null default 0;
+alter table v2_observations add column prog_time_amount_unit text not null default 'HR';
+alter table v2_observations add column part_time_amount_value numeric not null default 0;
+alter table v2_observations add column part_time_amount_unit text not null default 'HR';

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Observation.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Observation.java
@@ -59,6 +59,13 @@ public class Observation implements IValidateable {
     protected TimeAmount partTime;
 
     @Embedded
+    // For consistency
+    @AttributeOverrides({
+            @AttributeOverride(name = "value",
+                    column=@Column(name = "time_amount_value")),
+            @AttributeOverride(name = "units",
+                    column=@Column(name = "time_amount_unit"))
+    })
     protected TimeAmount time;
 
     @OneToMany(cascade = CascadeType.ALL,
@@ -136,6 +143,8 @@ public class Observation implements IValidateable {
             guideStars.add(new GuideStar(g, this));
         }
 
+        setProgTime(new TimeAmount(copied.getProgTime()));
+        setPartTime(new TimeAmount(copied.getPartTime()));
         setTime(new TimeAmount(copied.getTime()));
         setProposal(phaseIProposal);
         setBand(copied.getBand());

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Observation.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Observation.java
@@ -193,9 +193,7 @@ public class Observation implements IValidateable {
 
     public void setPartTime(TimeAmount partTime) { this.partTime = partTime; }
 
-    public void setTime(TimeAmount time) {
-        this.time = time;
-    }
+    public void setTime(TimeAmount time) { this.time = time; }
 
     public void setGuideStars(Set<GuideStar> guideStars) {
         this.guideStars = guideStars;
@@ -274,6 +272,8 @@ public class Observation implements IValidateable {
         if (metaData != null ? !metaData.equals(that.metaData) : that.metaData != null) return false;
         if (proposal != null ? !proposal.equals(that.proposal) : that.proposal != null) return false;
         if (target != null ? !target.equals(that.target) : that.target != null) return false;
+        if (progTime != null ? !progTime.equals(that.time) : that.progTime != null) return false;
+        if (partTime != null ? !partTime.equals(that.time) : that.partTime != null) return false;
         if (time != null ? !time.equals(that.time) : that.time != null) return false;
 
         return true;
@@ -296,6 +296,8 @@ public class Observation implements IValidateable {
         if (blueprint != null ? !blueprint.equalsForComponent(that.blueprint) : that.blueprint != null) return false;
         if (condition != null ? !condition.equals(that.condition) : that.condition != null) return false;
         if (target != null ? !target.equals(that.target) : that.target != null) return false;
+        if (progTime != null ? !progTime.equals(that.progTime) : that.progTime != null) return false;
+        if (partTime != null ? !partTime.equals(that.partTime) : that.partTime != null) return false;
         if (time != null ? !time.equals(that.time) : that.time != null) return false;
 
         return true;
@@ -306,6 +308,8 @@ public class Observation implements IValidateable {
         int result = target != null ? target.hashCode() : 0;
         result = 31 * result + (condition != null ? condition.hashCode() : 0);
         result = 31 * result + (blueprint != null ? blueprint.hashCode() : 0);
+        result = 31 * result + (progTime != null ? progTime.hashCode() : 0);
+        result = 31 * result + (partTime != null ? partTime.hashCode() : 0);
         result = 31 * result + (time != null ? time.hashCode() : 0);
         result = 31 * result + (proposal != null ? proposal.hashCode() : 0);
         result = 31 * result + (band != null ? band.hashCode() : 0);

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Observation.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Observation.java
@@ -41,6 +41,24 @@ public class Observation implements IValidateable {
     protected BlueprintBase blueprint;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value",
+                    column=@Column(name = "prog_time_amount_value")),
+            @AttributeOverride(name = "units",
+                    column=@Column(name = "prog_time_amount_unit"))
+    })
+    protected TimeAmount progTime;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value",
+                    column=@Column(name = "part_time_amount_value")),
+            @AttributeOverride(name = "units",
+                    column=@Column(name = "part_time_amount_unit"))
+    })
+    protected TimeAmount partTime;
+
+    @Embedded
     protected TimeAmount time;
 
     @OneToMany(cascade = CascadeType.ALL,
@@ -142,6 +160,10 @@ public class Observation implements IValidateable {
         return blueprint;
     }
 
+    public TimeAmount getProgTime() { return progTime; }
+
+    public TimeAmount getPartTime() { return partTime; }
+
     public TimeAmount getTime() {
         return time;
     }
@@ -157,6 +179,10 @@ public class Observation implements IValidateable {
     public void setBlueprint(BlueprintBase blueprint) {
         this.blueprint = blueprint;
     }
+
+    public void setProgTime(TimeAmount progTime) { this.progTime = progTime; }
+
+    public void setPartTime(TimeAmount partTime) { this.partTime = partTime; }
 
     public void setTime(TimeAmount time) {
         this.time = time;

--- a/phase1-data/src/main/java/edu/gemini/tac/util/HibernateToMutableConverter.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/util/HibernateToMutableConverter.java
@@ -160,6 +160,8 @@ public class HibernateToMutableConverter {
                     mo.setMeta(ho.getMetaData().toMutable());
                 }
 
+                mo.setProgTime(ho.getProgTime().toMutable());
+                mo.setPartTime(ho.getPartTime().toMutable());
                 mo.setTime(ho.getTime().toMutable());
                 mo.setBand(ho.getBand());
 

--- a/phase1-data/src/main/java/edu/gemini/tac/util/MutableToHibernateConverter.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/util/MutableToHibernateConverter.java
@@ -128,6 +128,12 @@ public class MutableToHibernateConverter {
 
             observation.setTarget(targetMap.get(mo.getTarget().getId()));
 
+            final TimeAmount progTimeAmount = new TimeAmount(mo.getProgTime());
+            observation.setProgTime(progTimeAmount);
+
+            final TimeAmount partTimeAmount = new TimeAmount(mo.getPartTime());
+            observation.setPartTime(partTimeAmount);
+
             final TimeAmount timeAmount = new TimeAmount(mo.getTime());
             observation.setTime(timeAmount);
 

--- a/phase1-data/src/test/java/edu/gemini/tac/persistence/fixtures/HibernateFixture.java
+++ b/phase1-data/src/test/java/edu/gemini/tac/persistence/fixtures/HibernateFixture.java
@@ -856,6 +856,8 @@ public class HibernateFixture extends Fixture {
             observation.setBlueprint(bb);
             observation.setGuideStars(gss);
             observation.setMetaData(observationMetaData);
+            observation.setProgTime(timeAmount);
+            observation.setPartTime(timeAmount);
             observation.setTime(timeAmount);
             observation.setTarget(t);
             if (i % 4 == 0)
@@ -924,6 +926,8 @@ public class HibernateFixture extends Fixture {
         Observation o = observations.get(i % observations.size());
         Observation o2 = new Observation();
         o2.setTarget(o.getTarget());
+        o2.setProgTime(o.getProgTime());
+        o2.setPartTime(o.getPartTime());
         o2.setTime(o.getTime());
         o2.setBlueprint(o.getBlueprint());
         o2.setCondition(o.getCondition());

--- a/phase1-data/src/test/java/edu/gemini/tac/persistence/fixtures/builders/ProposalBuilder.java
+++ b/phase1-data/src/test/java/edu/gemini/tac/persistence/fixtures/builders/ProposalBuilder.java
@@ -599,6 +599,8 @@ public abstract class ProposalBuilder {
         // put together the observation
         Observation o = new Observation();
         o.setBand(b);
+        o.setProgTime(new TimeAmount(0, TimeUnit.HR));
+        o.setPartTime(new TimeAmount(0, TimeUnit.HR));
         o.setTime(time);
         o.setProposal(phaseIProposal);
         // blueprint, condition and target have to be copied from "templates" (or re-used if they have already

--- a/phase1-services/src/main/java/edu/gemini/tac/service/ProposalHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/ProposalHibernateService.java
@@ -743,12 +743,6 @@ public class ProposalHibernateService implements IProposalService {
             Validate.notNull(band);
             observation.setBand(band);
         }
-        if (field.equals("observationTime")) {
-            final BigDecimal newTime = new BigDecimal(value);
-            fromValueBuffer.append(observation.getTime().getPrettyString());
-            Validate.notNull(newTime);
-            observation.setTime(new TimeAmount(newTime, TimeUnit.HR));
-        }
 
         return invalidateQueues;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <unitils.version>3.1</unitils.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.httpclient.version>3.1</commons.httpclient.version>
-        <ocs.model.p1.version>2017001.1.0</ocs.model.p1.version>
+        <ocs.model.p1.version>2017102.1.0</ocs.model.p1.version>
     </properties>
     <repositories>
         <repository>

--- a/queue-engine/qengine-p1-io/pom.xml
+++ b/queue-engine/qengine-p1-io/pom.xml
@@ -64,6 +64,11 @@
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-core_2.11</artifactId>
         </dependency>
+	<dependency>
+            <groupId>com.squants</groupId>
+            <artifactId>squants_2.11</artifactId> 
+            <version>0.6.2</version>
+	</dependency>
     </dependencies>
 
     <build>

--- a/queue-engine/qengine-p1-io/src/main/scala/edu/gemini/tac/qengine/p1/io/ObservationIo.scala
+++ b/queue-engine/qengine-p1-io/src/main/scala/edu/gemini/tac/qengine/p1/io/ObservationIo.scala
@@ -118,7 +118,7 @@ object ObservationIo {
   }
 
   def time(o: im.Observation): ValidationNel[String, Time] =
-    o.time.map(_.nonNegativeQueueEngineTime("observation")) | MISSING_TIME.failureNel[Time]
+    o.totalTime.map(_.nonNegativeQueueEngineTime("observation")) | MISSING_TIME.failureNel[Time]
 
   def lgs(o: im.Observation): ValidationNel[String, Boolean] =
     o.blueprint.map {

--- a/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ObservationIoTest.scala
+++ b/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ObservationIoTest.scala
@@ -100,7 +100,9 @@ class ObservationIoTest {
     }
 
   @Test def readNoBlueprint(): Unit = {
-    missing(ObservationIo.MISSING_BLUEPRINT) {
+    // With the new model if there is no blueprint the calculation for time
+    // fails. When an observation is read the time is read before the blueprint.
+    missing(ObservationIo.MISSING_TIME) {
       new ProposalFixture {
         override def observation = im.Observation(
           None,


### PR DESCRIPTION
Now it's possible to import a proposal from the latest PIT which includes the `progTime`s and `partTime`s XML tags and then export it from ITAC.

This PR also includes the SQL schema migration script.