### PR TITLE
REL-3096: Add explicit queue time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ target
 .classpath
 .project
 .settings
+.idea
+**/*.swp
 **/*.iml
 **/*.ipr
 itac-web/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,16 @@
                 <artifactId>scalaz-core_2.11</artifactId>
                 <version>7.2.2</version>
             </dependency>
+	    <dependency>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest_2.11</artifactId>
+                <version>3.0.1</version>
+	    </dependency>
+	    <dependency>
+                <groupId>org.scalacheck</groupId>
+                <artifactId>scalacheck_2.11</artifactId>
+                <version>1.13.4</version>
+	    </dependency>
             <dependency>
                 <groupId>gemini-nocs</groupId>
                 <artifactId>jsky-coords</artifactId>

--- a/queue-engine/qengine-api/pom.xml
+++ b/queue-engine/qengine-api/pom.xml
@@ -20,6 +20,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <dependencies>
+	<dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.11</artifactId>
+	    <scope>test</scope>
+	</dependency>
+	<dependency>
+            <groupId>org.scalacheck</groupId>
+            <artifactId>scalacheck_2.11</artifactId>
+	    <scope>test</scope>
+	</dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>

--- a/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/config/Default.scala
+++ b/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/config/Default.scala
@@ -30,7 +30,7 @@ object Default {
   val Band2Percent = Percent(30)
   val Band3Percent = Percent(20)
 
-  val BandPercentages = QueueBandPercentages()
+  val BandPercentages = QueueBandPercentages.Default
 
   val WvTimeRestriction  = TimeRestriction.wv(Percent(50), WV50)
   val LgsTimeRestriction = TimeRestriction.lgs(Time.hours(200))

--- a/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/config/ProportionalPartnerSequence.scala
+++ b/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/config/ProportionalPartnerSequence.scala
@@ -5,7 +5,7 @@ import org.apache.log4j.{Level, Logger}
 import xml.Elem
 
 class ProportionalPartnerSequence(seq: List[Partner], val site: Site, val initialPick: Partner) extends  edu.gemini.tac.qengine.api.config.PartnerSequence {
-  def this(seq : List[Partner], site : Site) = this(seq, site, seq.sortWith(_.percentAt(site) > _.percentAt(site)).head)
+  def this(seq : List[Partner], site : Site) = this(seq, site, seq.sortWith(_.percentDoubleAt(site) > _.percentDoubleAt(site)).head)
 
   private val LOGGER : Logger = Logger.getLogger(classOf[ProportionalPartnerSequence])
 

--- a/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/config/QueueBandPercentages.scala
+++ b/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/config/QueueBandPercentages.scala
@@ -7,12 +7,13 @@ import edu.gemini.tac.qengine.p1.QueueBand
  * Queue band percentages, the percent of total queue time to assign to each
  * band.  Defaults to 30/30/40.
  */
-final case class QueueBandPercentages(band1: Percent = Default.Band1Percent, band2: Percent = Default.Band2Percent, band3: Percent = Default.Band3Percent) {
+final case class QueueBandPercentages(band1: Percent, band2: Percent, band3: Percent) {
   /**
    * Determines what percent of the total queue is designated for the
    * specified band.
    */
-  val bandPercent: Map[QueueBand, Percent] = (QueueBand.values zip List(band1, band2, band3, Percent.Hundred - (band1 + band2 + band3))).toMap
+  val bandPercent: Map[QueueBand, Percent] =
+    (QueueBand.values zip List(band1, band2, band3, Percent.Hundred - (band1 + band2 + band3))).toMap
 
   require(bandPercent.values forall { perc => (perc >= Percent.Zero) && (perc <= Percent.Hundred) })
 
@@ -32,7 +33,10 @@ final case class QueueBandPercentages(band1: Percent = Default.Band1Percent, ban
 }
 
 object QueueBandPercentages {
-  def apply() = new QueueBandPercentages()
+  import edu.gemini.tac.qengine.api.config.Default.{Band1Percent, Band2Percent, Band3Percent}
+
+  val Default: QueueBandPercentages =
+    apply(Band1Percent, Band2Percent, Band3Percent)
 
   def apply(band1: Int, band2: Int, band3: Int) =
     new QueueBandPercentages(Percent(band1), Percent(band2), Percent(band3))

--- a/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/queue/time/PartnerTime.scala
+++ b/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/queue/time/PartnerTime.scala
@@ -85,7 +85,7 @@ object PartnerTime {
    */
   def distribute(total: Time, site: Site, partners: List[Partner]): PartnerTime = {
     val timeByPartner = partners.map { p =>
-      p -> Time.hours(total.toHours.value * p.percentAt(site) / 100.0)
+      p -> Time.hours(total.toHours.value * p.percentDoubleAt(site) / 100.0)
     }.toMap
     LOGGER.log(Level.DEBUG, "PartnerTime.distribute: " + timeByPartner)
     new PartnerTime(partners, timeByPartner)

--- a/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/queue/time/QueueTime.scala
+++ b/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/queue/time/QueueTime.scala
@@ -185,7 +185,7 @@ final class DerivedQueueTime(val site: Site,
     fullPartnerTime(p) * bandPercentages(cat)
 
   override def partnerPercent(p: Partner): Percent =
-    Percent(p.percentAt(site))
+    p.percentAt(site)
 
 }
 

--- a/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/queue/time/QueueTime.scala
+++ b/queue-engine/qengine-api/src/main/scala/edu/gemini/tac/qengine/api/queue/time/QueueTime.scala
@@ -9,6 +9,91 @@ import edu.gemini.tac.qengine.util.{Percent, Time}
 
 import java.util.logging.{Logger, Level}
 
+/** Record of queue times for each partner.  Provides access to the total queue
+  * time and the size of the time quantum for each partner.
+  */
+sealed trait QueueTime {
+  def fullPartnerTime: PartnerTime
+
+  def bandPercentages: QueueBandPercentages
+
+  def partnerOverfillAllowance: Option[Percent]
+
+  /** Total time for queue observing including guaranteed time and poor weather.
+   */
+  def full: Time
+
+  /** The time amount at which Band 1 scheduling ends. */
+  val band1End: Time
+
+  /** The time amount at which Band 2 scheduling ends. */
+  val band2End: Time
+
+  /** The time amount at which Band 3 scheduling ends (and alias for {@link #guaranteed}). */
+  val band3End: Time
+
+  /** The time amount at which Band 4 scheduling ends (an alias for {@link #full}). */
+  def band4End: Time
+
+  /** Calculates the PartnerTime for the given queue band. */
+  def partnerTime(band: QueueBand): PartnerTime
+
+  /** Calculates the PartnerTime for the given queue category. */
+  def partnerTime(cat: Category): PartnerTime
+
+  /** Time amount at which each particular queue band is defined to start and
+    * end.  This will differ from the actual queue band time ranges because
+    * proposals will not usually add up to exactly the amount of time available
+    * in a band.  Queue band 1 always starts at zero.
+    */
+  def range(band: QueueBand): (Time, Time)
+
+  /** Gets the nominal band that corresponds to the given time according only to
+    * the queue time and band percentages. In reality band 1 will usually extend
+    * into part of the time which was allocated for band 2 and band 2 will extend
+    * into band 3.
+    */
+  def band(time: Time): QueueBand
+
+  /** Size of time quantum as
+    * (partner queue time * 300) / (total queue time * partner percentage share)
+    */
+  def quantum(p: Partner): Time
+
+  /** Gets a map of Partner -> Time quantum with keys for all partners.
+    */
+  def partnerQuanta: PartnerTime
+
+  /** Computes the amount of time that is nominally designated for the given
+    * partner (independent of band, category, etc).  The actual amount of time
+    * will depend upon the times of the proposals in the queue.
+    */
+  def apply(partner: Partner): Time = fullPartnerTime(partner)
+
+  /** Computes the amount of time that is nominally designated for the given
+    * queue band.  The actual amount of time per band will depend upon the
+    * times of the proposals in the queue.
+    */
+  def apply(band: QueueBand): Time
+
+  /** Computes the amount of time that is nominally available for the given
+    * queue band category.  The actual amount of time per category will depend
+    * upon the times of the proposals in the queue.
+    */
+  def apply(cat: Category): Time
+
+  /** Computes the amount of time that is nominally designated for the given
+    * queue band and partner.
+    */
+  def apply(band: QueueBand, p: Partner): Time
+
+  /** Computes the amount of time that is nominally designated for the given
+    * queue band category and partner.
+    */
+  def apply(cat: Category, p: Partner): Time
+}
+
+
 object QueueTime {
   private val Log = Logger.getLogger(this.getClass.getName)
 
@@ -17,50 +102,48 @@ object QueueTime {
 
   val DefaultPartnerOverfillAllowance = Percent(5)
 
-  def apply(s: Site, m: Map[Partner, Time], partners: List[Partner]): QueueTime = new QueueTime(s, PartnerTime(partners, m))
+  def apply(s: Site, m: Map[Partner, Time], partners: List[Partner]): QueueTime =
+    apply(s, PartnerTime(partners, m))
+
+  def apply(s: Site, pt: PartnerTime): QueueTime =
+    apply(s, pt, QueueBandPercentages.Default, Some(QueueTime.DefaultPartnerOverfillAllowance))
+
+  def apply(s: Site, pt: PartnerTime, bp: QueueBandPercentages, poa: Option[Percent]): QueueTime =
+    new DerivedQueueTime(s, pt, bp, poa)
 }
 
 import QueueTime.Log
 
-/**
- * Record of queue times for each partner.  Provides access to the total queue
- * time and the size of the time quantum for each partner.
- */
-class QueueTime(site: Site,
+/** Implementation of `QueueTime` derived from overall partner allocation and
+  * band percentages.
+  */
+final class DerivedQueueTime(site: Site,
                 val fullPartnerTime: PartnerTime,
-                val bandPercentages: QueueBandPercentages = QueueBandPercentages(),
-                val partnerOverfillAllowance: Option[Percent] = Some(QueueTime.DefaultPartnerOverfillAllowance)) {
-  /**
-   * Total time for queue observing including guaranteed time and poor weather.
-   */
-  val full = fullPartnerTime.total.toHours
+                val bandPercentages: QueueBandPercentages,
+                val partnerOverfillAllowance: Option[Percent]) extends QueueTime {
 
-  /** The time amount at which Band 1 scheduling ends. */
-  val band1End = full * bandPercentages(QBand1)
+  override val full: Time =
+    fullPartnerTime.total.toHours
 
-  /** The time amount at which Band 2 scheduling ends. */
-  val band2End = full * bandPercentages(Category.B1_2)
+  override val band1End: Time =
+    full * bandPercentages(QBand1)
 
-  /** The time amount at which Band 3 scheduling ends (and alias for {@link #guaranteed}). */
-  val band3End = full * bandPercentages(Category.Guaranteed)
+  override val band2End: Time =
+    full * bandPercentages(Category.B1_2)
 
-  /** The time amount at which Band 4 scheduling ends (an alias for {@link #full}). */
-  def band4End = full
+  override val band3End: Time =
+    full * bandPercentages(Category.Guaranteed)
 
-  /** Calculates the PartnerTime for the given queue band. */
-  def partnerTime(band: QueueBand): PartnerTime = fullPartnerTime * bandPercentages(band)
+  override def band4End: Time =
+    full
 
-  /** Calculates the PartnerTime for the given queue category. */
-  def partnerTime(cat: Category): PartnerTime   = fullPartnerTime * bandPercentages(cat)
+  override def partnerTime(band: QueueBand): PartnerTime =
+    fullPartnerTime * bandPercentages(band)
 
+  override def partnerTime(cat: Category): PartnerTime   =
+    fullPartnerTime * bandPercentages(cat)
 
-  /**
-   * Time amount at which each particular queue band is defined to start and
-   * end.  This will differ from the actual queue band time ranges because
-   * proposals will not usually add up to exactly the amount of time available
-   * in a band.  Queue band 1 always starts at zero.
-   */
-  def range(band: QueueBand): (Time, Time) =
+  override def range(band: QueueBand): (Time, Time) =
     band match {
       case QBand1 => (Time.ZeroHours, band1End)
       case QBand2 => (band1End,       band2End)
@@ -68,13 +151,7 @@ class QueueTime(site: Site,
       case QBand4 => (band3End,       band4End)
     }
 
-  /**
-   * Gets the nominal band that corresponds to the given time according only to
-   * the queue time and band percentages. In reality band 1 will usually extend
-   * into part of the time which was allocated for band 2 and band 2 will extend
-   * into band 3.
-   */
-  def band(time: Time): QueueBand =
+  override def band(time: Time): QueueBand =
     time match {
       case u if u < band1End  => QBand1
       case u if u < band2End  => QBand2
@@ -82,67 +159,33 @@ class QueueTime(site: Site,
       case _                  => QBand4
     }
 
-  /**
-   * Computes the amount of time that is nominally designated for the given
-   * partner (independent of band, category, etc).  The actual amount of time
-   * will depend upon the times of the proposals in the queue.
-   */
-  def apply(partner: Partner): Time = fullPartnerTime(partner)
+  override def apply(partner: Partner): Time =
+    fullPartnerTime(partner)
 
-  /**
-   * Computes the amount of time that is nominally designated for the given
-   * queue band.  The actual amount of time per band will depend upon the
-   * times of the proposals in the queue.
-   */
-  def apply(band: QueueBand): Time = full * bandPercentages(band)
+  override def apply(band: QueueBand): Time =
+    full * bandPercentages(band)
 
-  /**
-   * Computes the amount of time that is nominally available for the given
-   * queue band category.  The actual amount of time per category will depend
-   * upon the times of the proposals in the queue.
-   */
-  def apply(cat: Category) = full * bandPercentages(cat)
+  override def apply(cat: Category): Time =
+    full * bandPercentages(cat)
 
-  /**
-   * Computes the amount of time that is nominally designated for the given
-   * queue band and partner.
-   */
-  def apply(band: QueueBand, p: Partner): Time =
+  override def apply(band: QueueBand, p: Partner): Time =
     fullPartnerTime(p) * bandPercentages(band)
 
-  /**
-   * Computes the amount of time that is nominally designated for the given
-   * queue band category and partner.
-   */
-  def apply(cat: Category, p: Partner): Time =
+  override def apply(cat: Category, p: Partner): Time =
     fullPartnerTime(p) * bandPercentages(cat)
 
-
-  /*
-  Calculates the quanta appropriate for a partner over the course of a 100-partner "cycle"
-  This is not precisely equal to partner % * CycleTimeConstant because the {@link PartnerTimeCalc}
-  has subtracted {@link PartnerTime}s for, e.g., classical programs.
-   */
-  private def quantum(p: Partner, t: Time): Time = {
+  override def quantum(p: Partner): Time = {
     val fullQueueTimeForThisPartnerTimesOneHundred = full.toHours.value * p.percentAt(site)
-    if (fullQueueTimeForThisPartnerTimesOneHundred == 0) Time.ZeroHours else {
-      val d1 = t.toHours.value * QueueTime.CycleTimeConstant
+    if (fullQueueTimeForThisPartnerTimesOneHundred == 0)
+      Time.ZeroHours
+    else {
+      val d1 = fullPartnerTime(p).toHours.value * QueueTime.CycleTimeConstant
       Time.hours(d1/fullQueueTimeForThisPartnerTimesOneHundred)
     }
   }
 
-  /**
-   * Size of time quantum us
-   * (partner queue time * 300) / (total queue time * partner percentage share)
-   */
-  def quantum(p: Partner): Time = quantum(p, fullPartnerTime(p))
-
-  /**
-   * Gets a map of Partner -> Time quantum with keys for all partners.
-   */
-  def partnerQuanta: PartnerTime = {
-    val pq = fullPartnerTime.mapTimes(quantum)
-    Log.log(Level.FINE, pq.toString)
-    pq
+  override def partnerQuanta: PartnerTime = {
+    val ps = fullPartnerTime.partners
+    PartnerTime(ps, ps.map { p => p -> quantum(p) }: _*)
   }
 }

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/config/PartnerSequenceTest.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/config/PartnerSequenceTest.scala
@@ -36,9 +36,9 @@ class PartnerSequenceTest {
     Site.values.foreach { site =>
       val first100 = new ProportionalPartnerSequence(partners, site).sequence.take(100).toList
       val counts = first100.groupBy(identity).mapValues(_.size)
-      val sumOfAllocations = partners.foldRight(0.0)(_.percentAt(site) + _)
+      val sumOfAllocations = partners.foldRight(0.0)(_.percentDoubleAt(site) + _)
       partners.foreach { p =>
-        val expected = p.percentAt(site) / sumOfAllocations
+        val expected = p.percentDoubleAt(site) / sumOfAllocations
         val achieved =
           counts.contains(p) match {
             case true => counts(p) / 100.0

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/config/QueueBandPercentagesTest.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/config/QueueBandPercentagesTest.scala
@@ -19,11 +19,11 @@ class QueueBandPercentagesTest {
   }
 
   @Test def testDefault() {
-    verify(QueueBandPercentages(), 30, 30, 20)
+    verify(QueueBandPercentages.Default, 30, 30, 20)
   }
 
   @Test def testNonDefault() {
-    verify(QueueBandPercentages(Percent(10), Percent(20)), 10, 20, 20)
+    verify(QueueBandPercentages(Percent(10), Percent(20), Default.Band3Percent), 10, 20, 20)
   }
 
   @Test def testNonDefaultInt() {
@@ -67,7 +67,7 @@ class QueueBandPercentagesTest {
   }
 
   @Test def testToString() {
-    val percs0 = QueueBandPercentages()
+    val percs0 = QueueBandPercentages.Default
     assertEquals("(B1=30%, B2=30%, B3=20%)", percs0.toString)
 
     val percs1 = QueueBandPercentages(10, 20, 40)

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/Arbitraries.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/Arbitraries.scala
@@ -1,0 +1,39 @@
+package edu.gemini.tac.qengine.api.queue.time
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary._
+
+import edu.gemini.tac.qengine.ctx.{Partner, TestPartners}
+import edu.gemini.tac.qengine.p1.QueueBand
+import edu.gemini.tac.qengine.util.{Percent, Time}
+
+trait Arbitraries {
+  implicit val arbitraryPartner: Arbitrary[Partner] =
+    Arbitrary {
+      oneOf(TestPartners.All)
+    }
+
+  implicit val arbitraryQueueBand: Arbitrary[QueueBand] =
+    Arbitrary {
+      oneOf(QueueBand.values)
+    }
+
+  implicit val arbitraryTime: Arbitrary[Time] =
+    Arbitrary {
+      posNum[Long].map { Time.millisecs }
+    }
+
+  implicit val arbitraryPercent: Arbitrary[Percent] =
+    Arbitrary {
+      choose(0.0, 1.0).map { Percent.fromQuotient }
+    }
+
+  implicit val arbitraryQueueTime: Arbitrary[QueueTime] =
+    Arbitrary {
+      for {
+        m <- arbitrary[Map[(Partner, QueueBand), Time]]
+        p <- arbitrary[Option[Percent]]
+      } yield new ExplicitQueueTime(m, p)
+    }
+}

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/ExplicitQueueTimeTest.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/ExplicitQueueTimeTest.scala
@@ -1,0 +1,43 @@
+package edu.gemini.tac.qengine.api.queue.time
+
+import edu.gemini.tac.qengine.util.Time
+import edu.gemini.tac.qengine.p1.QueueBand
+import edu.gemini.tac.qengine.p1.QueueBand._
+
+import edu.gemini.tac.qengine.ctx.{TestPartners, Partner, Site}
+
+import org.scalatest._
+import org.scalatest.prop._
+import Matchers._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ExplicitQueueTimeTest extends PropSpec with PropertyChecks with Arbitraries {
+  def sum(it: Iterable[Time]): Long =
+    it.map(_.ms).sum
+
+  property("Sum of fullPartnerTime is equal to full") {
+    forAll { (qt: QueueTime) =>
+      sum(qt.fullPartnerTime.map.values) shouldBe qt.full.ms
+    }
+  }
+
+  property("band1End is equal to band 1 time") {
+    forAll { (qt: QueueTime) =>
+      qt.band1End shouldBe qt(QBand1)
+    }
+  }
+
+  property("band2End - band1End is equal to band 2 time") {
+    forAll { (qt: QueueTime) =>
+      (qt.band2End - qt.band1End) shouldBe qt(QBand2)
+    }
+  }
+
+  property("band3End - band2End is equal to band 3 time") {
+    forAll { (qt: QueueTime) =>
+      (qt.band3End - qt.band2End) shouldBe qt(QBand3)
+    }
+  }
+}

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/PartnerTimeCalcTest.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/PartnerTimeCalcTest.scala
@@ -24,9 +24,9 @@ class PartnerTimeCalcTest extends PartnerTimeCalcTestBase {
 
   @Test def testBaseTime() {
     val b = base(north, Time.hours(100),  partners)
-    assertEquals(Time.hours(US.percentAt(north)), b(US))
+    assertEquals(Time.hours(US.percentDoubleAt(north)), b(US))
     assertEquals(Time.hours(0), b(CL)) // no CL at GN
-    assertEquals(Time.hours(UH.percentAt(north)), b(UH))
+    assertEquals(Time.hours(UH.percentDoubleAt(north)), b(UH))
   }
 
   @Test def testSimpleNet() {
@@ -36,8 +36,8 @@ class PartnerTimeCalcTest extends PartnerTimeCalcTestBase {
     val r = PartnerTime(partners, US -> Time.hours(20))
     val n = net(b, partners, c, r)
 
-    assertEquals(US.percentAt(north) - 5.0 - 20.0, n(US).toHours.value, delta) // 5 classical, 20 rollover
-    assertEquals(AR.percentAt(north), n(AR).toHours.value, delta) // no adjustments
+    assertEquals(US.percentDoubleAt(north) - 5.0 - 20.0, n(US).toHours.value, delta) // 5 classical, 20 rollover
+    assertEquals(AR.percentDoubleAt(north), n(AR).toHours.value, delta) // no adjustments
   }
 
   @Test def testNoNegativeResult() {
@@ -48,6 +48,6 @@ class PartnerTimeCalcTest extends PartnerTimeCalcTestBase {
     val n = net(b, partners, c, r)
 
     assertEquals(Time.hours(0), n(US)) // not negative
-    assertEquals(AR.percentAt(north), n(AR).toHours.value, delta) // no adjustments
+    assertEquals(AR.percentDoubleAt(north), n(AR).toHours.value, delta) // no adjustments
   }
 }

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/PartnerTimeTest.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/PartnerTimeTest.scala
@@ -23,10 +23,10 @@ class PartnerTimeTest {
   }
 
   @Test def testCalc() {
-    val pt = PartnerTime.calc(partners, p => Time.hours(p.percentAt(site)))
+    val pt = PartnerTime.calc(partners, p => Time.hours(p.percentDoubleAt(site)))
 
-    assertEquals(Time.hours(US.percentAt(site)), pt(US))
-    partners.foreach(p => assertEquals(Time.hours(p.percentAt(site)), pt(p)))
+    assertEquals(Time.hours(US.percentDoubleAt(site)), pt(US))
+    partners.foreach(p => assertEquals(Time.hours(p.percentDoubleAt(site)), pt(p)))
   }
 
   @Test def testConstant() {
@@ -42,10 +42,10 @@ class PartnerTimeTest {
   @Test
   def distributeBasedOnPartnerPercentages(): Unit = {
     val pt = PartnerTime.distribute(Time.hours(100), site, partners)
-    assertEquals(Time.hours(US.percentAt(site)), pt(US))
-    assertEquals(Time.hours(BR.percentAt(site)), pt(BR))
+    assertEquals(Time.hours(US.percentDoubleAt(site)), pt(US))
+    assertEquals(Time.hours(BR.percentDoubleAt(site)), pt(BR))
     partners.foreach { p =>
-      val partnerPercentAtSite = p.percentAt(site)
+      val partnerPercentAtSite = p.percentDoubleAt(site)
       assertEquals("Failed for partner " + p.fullName, Time.hours(100) * Percent(partnerPercentAtSite), pt(p))
     }
   }
@@ -62,8 +62,8 @@ class PartnerTimeTest {
     val pt2 = PartnerTime.constant(Time.hours(1), partners)
     val pt3 = pt1 - pt2
 
-    assertEquals(Time.hours(US.percentAt(site) - 1.0), pt3(US))
-    assertEquals(Time.hours(BR.percentAt(site) - 1.0), pt3(BR))
+    assertEquals(Time.hours(US.percentDoubleAt(site) - 1.0), pt3(US))
+    assertEquals(Time.hours(BR.percentDoubleAt(site) - 1.0), pt3(BR))
 
   }
 
@@ -72,16 +72,16 @@ class PartnerTimeTest {
     val pt2 = PartnerTime.constant(Time.hours(1), partners)
     val pt3 = pt1 + pt2
 
-    assertEquals(Time.hours(US.percentAt(site) + 1.0), pt3(US))
-    assertEquals(Time.hours(BR.percentAt(site) + 1.0), pt3(BR))
+    assertEquals(Time.hours(US.percentDoubleAt(site) + 1.0), pt3(US))
+    assertEquals(Time.hours(BR.percentDoubleAt(site) + 1.0), pt3(BR))
   }
 
   @Test def multiplyByPercentAcrossPartners(): Unit = {
     val pt1 = PartnerTime.distribute(Time.hours(100), site, partners)
     val pt2 = pt1 * Percent(10)
 
-    assertEquals(Time.hours(US.percentAt(site) * 0.1), pt2(US))
-    assertEquals(Time.hours(BR.percentAt(site) * 0.1), pt2(BR))
+    assertEquals(Time.hours(US.percentDoubleAt(site) * 0.1), pt2(US))
+    assertEquals(Time.hours(BR.percentDoubleAt(site) * 0.1), pt2(BR))
   }
 
   @Test def totalTimeIsEqualToDistributedTime(): Unit = {
@@ -91,6 +91,6 @@ class PartnerTimeTest {
 
   @Test def distributesRolloverTimeEvenly(): Unit = {
     val pt = PartnerTime.distribute(Time.hours(100), site, partners)
-    pt.map.map(kv => assertEquals(Time.hours(kv._1.percentAt(site)), kv._2))
+    pt.map.map(kv => assertEquals(Time.hours(kv._1.percentDoubleAt(site)), kv._2))
   }
 }

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/QueueTimeTest.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/QueueTimeTest.scala
@@ -43,10 +43,10 @@ class QueueTimeTest {
     timeEquals(0, qtime.quantum(AR))
     timeEquals(0, qtime.partnerQuanta(AR))
 
-    timeEquals((100 * 300) / (120 * US.percentAt(site)), qtime.quantum(US))
+    timeEquals((100 * 300) / (120 * US.percentDoubleAt(site)), qtime.quantum(US))
 
     // BR = (20 * 300) / (120 * 5)
-    timeEquals((20 * 300) / (120 * BR.percentAt(site)), qtime.quantum(BR))
+    timeEquals((20 * 300) / (120 * BR.percentDoubleAt(site)), qtime.quantum(BR))
   }
 
   private def verifyTimes(lst: List[Time], f: QueueBand => Time) {

--- a/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/RolloverTimeTest.scala
+++ b/queue-engine/qengine-api/src/test/scala/edu/gemini/tac/qengine/api/queue/time/RolloverTimeTest.scala
@@ -32,7 +32,7 @@ class RolloverTimeTest extends PartnerTimeCalcTestBase {
     val pt = rollover(Site.north, rop, partners)
     assertEquals(pt.total.toHours.value, 100.0, Double.MinValue)
     partners.foreach {
-      p => assertEquals("Wrong time for " + p.id , pt(p).toHours.value, p.percentAt(Site.north), Double.MinValue)
+      p => assertEquals("Wrong time for " + p.id , pt(p).toHours.value, p.percentDoubleAt(Site.north), Double.MinValue)
     }
   }
 

--- a/queue-engine/qengine-ctx/src/main/scala/edu/gemini/tac/qengine/ctx/Partner.scala
+++ b/queue-engine/qengine-ctx/src/main/scala/edu/gemini/tac/qengine/ctx/Partner.scala
@@ -28,7 +28,11 @@ case class Partner(id: String, fullName: String, share: Percent, sites: Set[Site
   /**
    * Gets the partner's percentage share at the given site.
    */
-  def percentAt(s: Site): Double = if (sites.contains(s)) share.doubleValue else 0.0
+  def percentAt(s: Site): Percent =
+    if (sites.contains(s)) share else Percent.Zero
+
+  def percentDoubleAt(s: Site): Double =
+    percentAt(s).doubleValue
 
   override def toString: String = id
 

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/QueueEngineTest.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/QueueEngineTest.scala
@@ -51,7 +51,7 @@ class QueueEngineTest {
       UH -> Time.hours(163.0),
       GS -> Time.hours(108.0)
     )
-    new QueueTime(site, PartnerTime(partners, ptimes: _*))
+    QueueTime(site, ptimes.toMap, partners)
   }
 
   def decBinGroup: DecBinGroup[Percent] = {

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/RandomQueueTest.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/RandomQueueTest.scala
@@ -20,7 +20,7 @@ class RandomQueueTest {
   private def randomTime(max: Int): Time = Time.hours(max * rand.nextDouble)
 
   private def queueTime: QueueTime =
-    QueueTime(site, partners.map(p => (p, Time.hours(1000) * Percent(p.percentAt(site)))).toMap, partners)
+    QueueTime(site, partners.map(p => (p, Time.hours(1000) * Percent(p.percentDoubleAt(site)))).toMap, partners)
 
   // Ra Bins for GN-A
   private def raLimits: RaBinGroup[Time] =

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/EagerProposalQueueTest.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/EagerProposalQueueTest.scala
@@ -39,7 +39,7 @@ class EagerProposalQueueTest {
   private def otherPart(propTimeHours: Int, ref: String, mp: JointProposalPart): JointProposalPart =
     JointProposalPart(mp.jointIdValue, mp.core.copy(ntac = Ntac(GS, ref, 0, Time.hours(propTimeHours))))
 
-  private val qs = ProposalQueueBuilder(new QueueTime(Site.south, PartnerTime(partners, GS -> Time.hours(100)), QueueBandPercentages(30, 30, 40)), EagerMergeStrategy)
+  private val qs = ProposalQueueBuilder(QueueTime(Site.south, PartnerTime(partners, GS -> Time.hours(100)), QueueBandPercentages(30, 30, 40), Some(QueueTime.DefaultPartnerOverfillAllowance)), EagerMergeStrategy)
   private val qtime = qs.queueTime
 
   @Test def testPromotePart() {

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/FinalProposalQueueTest.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/FinalProposalQueueTest.scala
@@ -51,7 +51,7 @@ class FinalProposalQueueTest {
     assertEquals(Nil, queue.zipWithPosition)
     assertTrue(queue.positionOf(mkProp(GS, 1, "GS-1")).isEmpty)
 
-    verifyTime(US.percentAt(site), queue.remainingTime(US))
+    verifyTime(US.percentDoubleAt(site), queue.remainingTime(US))
   }
 
   @Test def testSingleProposal() {
@@ -75,8 +75,8 @@ class FinalProposalQueueTest {
     assertEquals(Some(expectedPos), queue.positionOf(gs1))
 
     verifyTime(99.0, queue.remainingTime)
-    verifyTime(GS.percentAt(site) - 1, queue.remainingTime(GS))
-    verifyTime(US.percentAt(site), queue.remainingTime(US))
+    verifyTime(GS.percentDoubleAt(site) - 1, queue.remainingTime(GS))
+    verifyTime(US.percentDoubleAt(site), queue.remainingTime(US))
     verifyTime(queueTime(Category.B1_2).toHours.value - 1, queue.remainingTime(Category.B1_2))
     verifyTime(queueTime(Category.Guaranteed).toHours.value - 1, queue.remainingTime(Category.Guaranteed))
   }
@@ -113,8 +113,8 @@ class FinalProposalQueueTest {
     assertEquals(Some(gsPos), queue.positionOf(gs3))
 
     verifyTime(92.0, queue.remainingTime)
-    verifyTime(GS.percentAt(site) - 3, queue.remainingTime(GS))
-    verifyTime(US.percentAt(site) - 4, queue.remainingTime(US))
+    verifyTime(GS.percentDoubleAt(site) - 3, queue.remainingTime(GS))
+    verifyTime(US.percentDoubleAt(site) - 4, queue.remainingTime(US))
     verifyTime(queueTime(Category.B1_2).toHours.value - 1, queue.remainingTime(Category.B1_2)) // 1 hr band 1,2
     verifyTime(queueTime(Category.Guaranteed).toHours.value - 4, queue.remainingTime(Category.Guaranteed)) // 4 hrs band 1,2,3
   }
@@ -154,10 +154,10 @@ class FinalProposalQueueTest {
     assertEquals(Some(gsPos), queue.positionOf(gs4))
 
     verifyTime(90.0, queue.remainingTime)
-    verifyTime(AU.percentAt(site) - 1.0, queue.remainingTime(AU))
-    verifyTime(CA.percentAt(site) - 1.0, queue.remainingTime(CA))
-    verifyTime(GS.percentAt(site) - 4.0, queue.remainingTime(GS))
-    verifyTime(US.percentAt(site) - 4.0, queue.remainingTime(US))
+    verifyTime(AU.percentDoubleAt(site) - 1.0, queue.remainingTime(AU))
+    verifyTime(CA.percentDoubleAt(site) - 1.0, queue.remainingTime(CA))
+    verifyTime(GS.percentDoubleAt(site) - 4.0, queue.remainingTime(GS))
+    verifyTime(US.percentDoubleAt(site) - 4.0, queue.remainingTime(US))
     verifyTime(queueTime(Category.B1_2).toHours.value - 2.0, queue.remainingTime(Category.B1_2))
     verifyTime(queueTime(Category.Guaranteed).toHours.value - 10.0, queue.remainingTime(Category.Guaranteed))
   }

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/FinalProposalQueueTest.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/FinalProposalQueueTest.scala
@@ -19,7 +19,7 @@ class FinalProposalQueueTest {
 
   val delta     = 0.000001
   val site      = Site.south
-  val queueTime = new QueueTime(site, PartnerTime.distribute(Time.hours(100), site, partners))
+  val queueTime = QueueTime(site, PartnerTime.distribute(Time.hours(100), site, partners))
 
   private def mkProp(partner: Partner, propTimeHours: Int, id: String): CoreProposal = {
     val ntac = Ntac(partner, id, 0, Time.hours(propTimeHours))

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/ProposalBuilderTest.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/ProposalBuilderTest.scala
@@ -174,7 +174,7 @@ class ProposalBuilderTest {
 
   @Test def testAddJointProposal() {
     val site = Site.south
-    val qs = ProposalQueueBuilder(new QueueTime(site, PartnerTime.distribute(Time.hours(100), site, partners)))
+    val qs = ProposalQueueBuilder(QueueTime(site, PartnerTime.distribute(Time.hours(100), site, partners)))
     val propGS = mkProp(10, "gs1")
     val propUS = mkProp(US, 20, "us1")
     val joint = new JointProposal("j1", propGS, List(propGS.ntac, propUS.ntac))

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/ProposalBuilderTest.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/queue/ProposalBuilderTest.scala
@@ -187,19 +187,19 @@ class ProposalBuilderTest {
     assertEquals(Time.hours(10), qs1.usedTime(GS))
     assertEquals(Time.hours(20), qs1.usedTime(US))
     assertEquals(Time.ZeroHours, qs1.usedTime(AU))
-    assertEquals(Time.hours(GS.percentAt(site) - 10), qs1.remainingTime(GS))
-    assertEquals(Time.hours(US.percentAt(site) - 20), qs1.remainingTime(US))
-    assertEquals(Time.hours(AU.percentAt(site)), qs1.remainingTime(AU))
+    assertEquals(Time.hours(GS.percentDoubleAt(site) - 10), qs1.remainingTime(GS))
+    assertEquals(Time.hours(US.percentDoubleAt(site) - 20), qs1.remainingTime(US))
+    assertEquals(Time.hours(AU.percentDoubleAt(site)), qs1.remainingTime(AU))
 
     assertEquals(Time.hours(50), qs1.remainingTime(Guaranteed))
-    assertEquals(Time.hours(US.percentAt(site) * 0.8 - 20.0), qs1.remainingTime(Guaranteed, US))
-    assertEquals(Time.hours(GS.percentAt(site) * 0.8 - 10.0), qs1.remainingTime(Guaranteed, GS))
-    assertEquals(Time.hours(AU.percentAt(site) * 0.8), qs1.remainingTime(Guaranteed, AU))
+    assertEquals(Time.hours(US.percentDoubleAt(site) * 0.8 - 20.0), qs1.remainingTime(Guaranteed, US))
+    assertEquals(Time.hours(GS.percentDoubleAt(site) * 0.8 - 10.0), qs1.remainingTime(Guaranteed, GS))
+    assertEquals(Time.hours(AU.percentDoubleAt(site) * 0.8), qs1.remainingTime(Guaranteed, AU))
 
     assertEquals(Time.hours(20), qs1.remainingTime(PoorWeather))
-    assertEquals(Time.hours(US.percentAt(site) * 0.2), qs1.remainingTime(PoorWeather, US))
-    assertEquals(Time.hours(GS.percentAt(site) * 0.2), qs1.remainingTime(PoorWeather, GS))
-    assertEquals(Time.hours(AU.percentAt(site) * 0.2), qs1.remainingTime(PoorWeather, AU))
+    assertEquals(Time.hours(US.percentDoubleAt(site) * 0.2), qs1.remainingTime(PoorWeather, US))
+    assertEquals(Time.hours(GS.percentDoubleAt(site) * 0.2), qs1.remainingTime(PoorWeather, GS))
+    assertEquals(Time.hours(AU.percentDoubleAt(site) * 0.2), qs1.remainingTime(PoorWeather, AU))
   }
 
   @Test def testAddAllProposals() {

--- a/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/resource/Fixture.scala
+++ b/queue-engine/qengine-impl/src/test/scala/edu/gemini/tac/qengine/impl/resource/Fixture.scala
@@ -67,8 +67,6 @@ object Fixture {
 
   def evenQueue(hrs: Double, overfill: Option[Percent]): ProposalQueueBuilder = {
     val pt = PartnerTime(partners, partners.map(p => (p, Time.hours(hrs))): _*)
-    ProposalQueueBuilder(
-      new QueueTime(site, pt, partnerOverfillAllowance = overfill)
-    )
+    ProposalQueueBuilder(QueueTime(site, pt, QueueBandPercentages.Default, overfill))
   }
 }

--- a/queue-engine/qengine-p1/src/test/scala/edu/gemini/tac/qengine/p1/ProposalTest.scala
+++ b/queue-engine/qengine-p1/src/test/scala/edu/gemini/tac/qengine/p1/ProposalTest.scala
@@ -11,7 +11,7 @@ class ProposalTest {
     val p = Mockito.mock(classOf[Partner])
     Mockito.when(p.id).thenReturn(partnerCountryKey)
     Mockito.when(p.share).thenReturn(Percent(proportion * 100.0))
-    Mockito.when(p.percentAt(Matchers.anyObject())).thenReturn(proportion)
+    Mockito.when(p.percentDoubleAt(Matchers.anyObject())).thenReturn(proportion)
     p
   }
 

--- a/queue-service/ps-conversion/src/main/scala/edu/gemini/tac/psconversion/PartnerSequenceConverter.scala
+++ b/queue-service/ps-conversion/src/main/scala/edu/gemini/tac/psconversion/PartnerSequenceConverter.scala
@@ -42,7 +42,7 @@ object PartnerSequenceConverter {
         else BadData(s"Initial pick $p not included in partner list: ${allPartners.mkString(", ")}").left[Option[Partner]]
       }
 
-    def highestPerc: Partner = allPartners.maxBy(_.percentAt(site))
+    def highestPerc: Partner = allPartners.maxBy(_.percentDoubleAt(site))
 
     for {
       _    <- if (allPartners.size == 0) BadData("No partners have been defined").left else ().right

--- a/queue-service/qservice-impl/src/main/scala/edu/gemini/tac/qservice/impl/queue/time/QueueTimeExtractor.scala
+++ b/queue-service/qservice-impl/src/main/scala/edu/gemini/tac/qservice/impl/queue/time/QueueTimeExtractor.scala
@@ -182,6 +182,6 @@ class QueueTimeExtractor(queue: PsQueue, partners: List[Partner], rop: RolloverR
       ptc <- partnerTimeCalc
       p   <- bandPercentages
       of  <- overfillFactor
-    } yield new QueueTime(ctx.getSite, ptc.net, p, Some(of))
+    } yield QueueTime(ctx.getSite, ptc.net, p, Some(of))
 }
 

--- a/queue-service/qservice-impl/src/test/scala/edu/gemini/tac/qservice/impl/TestQueueServiceImpl.scala
+++ b/queue-service/qservice-impl/src/test/scala/edu/gemini/tac/qservice/impl/TestQueueServiceImpl.scala
@@ -137,7 +137,7 @@ class TestQueueServiceImpl {
 
     partners.values foreach { p =>
       val pc = avail(partners.psPartnerFor(p))
-      assertEquals(p.percentAt(Site.north), pc.getCharge.getDoubleValue, 0.000001)
+      assertEquals(p.percentDoubleAt(Site.north), pc.getCharge.getDoubleValue, 0.000001)
     }
 
     // Check that there is no classical time

--- a/queue-service/qservice-impl/src/test/scala/edu/gemini/tac/qservice/impl/queue/time/QueueTimeExtractorTest.scala
+++ b/queue-service/qservice-impl/src/test/scala/edu/gemini/tac/qservice/impl/queue/time/QueueTimeExtractorTest.scala
@@ -127,7 +127,7 @@ class QueueTimeExtractorTest{
     assertEquals(US.percentDoubleAt(Site.north), m(US).toHours.value, 0.000001)
     assertEquals(BR.percentDoubleAt(Site.north), m(BR).toHours.value, 0.000001)
     partners.foreach {
-      p => assertEquals("Wrong percentage for " + p.id , p.percentAt(Site.north), m(p).toHours.value, Double.MinValue)
+      p => assertEquals("Wrong percentage for " + p.id , p.percentDoubleAt(Site.north), m(p).toHours.value, Double.MinValue)
     }
 
     assertEquals(q.getBand1Cutoff.intValue, a.bandPercentages.toOption.get.band1.doubleValue, Double.MinPositiveValue)

--- a/queue-service/qservice-impl/src/test/scala/edu/gemini/tac/qservice/impl/queue/time/QueueTimeExtractorTest.scala
+++ b/queue-service/qservice-impl/src/test/scala/edu/gemini/tac/qservice/impl/queue/time/QueueTimeExtractorTest.scala
@@ -124,8 +124,8 @@ class QueueTimeExtractorTest{
 
     val a = new QueueTimeExtractor(q, partners)
     val m = a.extract.toOption.get.fullPartnerTime
-    assertEquals(US.percentAt(Site.north), m(US).toHours.value, 0.000001)
-    assertEquals(BR.percentAt(Site.north), m(BR).toHours.value, 0.000001)
+    assertEquals(US.percentDoubleAt(Site.north), m(US).toHours.value, 0.000001)
+    assertEquals(BR.percentDoubleAt(Site.north), m(BR).toHours.value, 0.000001)
     partners.foreach {
       p => assertEquals("Wrong percentage for " + p.id , p.percentAt(Site.north), m(p).toHours.value, Double.MinValue)
     }
@@ -196,18 +196,18 @@ class QueueTimeExtractorTest{
     )
     val rop = RolloverReport(List(ro))
 
-    def roTime(p: Partner): Double = p.percentAt(Site.north)/10.0
+    def roTime(p: Partner): Double = p.percentDoubleAt(Site.north)/10.0
 
     val a = new QueueTimeExtractor(q, partners, rop, List(us))
     val m = a.extract.toOption.get.fullPartnerTime
-    assertSameTime(US.percentAt(Site.north) - 5.0 - roTime(US), m(US))
-    assertSameTime(AR.percentAt(Site.north) - roTime(AR), m(AR))
-    assertSameTime(BR.percentAt(Site.north) - 1.0 - roTime(BR), m(BR))
-    assertSameTime(UH.percentAt(Site.north) - roTime(UH), m(UH))
+    assertSameTime(US.percentDoubleAt(Site.north) - 5.0 - roTime(US), m(US))
+    assertSameTime(AR.percentDoubleAt(Site.north) - roTime(AR), m(AR))
+    assertSameTime(BR.percentDoubleAt(Site.north) - 1.0 - roTime(BR), m(BR))
+    assertSameTime(UH.percentDoubleAt(Site.north) - roTime(UH), m(UH))
 
     val ptc = a.partnerTimeCalc.toOption.get
-    assertSameTime(US.percentAt(Site.north), ptc.base(US))
-    assertSameTime(AR.percentAt(Site.north), ptc.base(AR))
+    assertSameTime(US.percentDoubleAt(Site.north), ptc.base(US))
+    assertSameTime(AR.percentDoubleAt(Site.north), ptc.base(AR))
     assertSameTime( 5.0, ptc.classical(US))
     assertSameTime( 0.0, ptc.classical(UH))
     assertSameTime( 1.0, ptc.exchange(BR))


### PR DESCRIPTION
This PR is an update to the ITAC queue engine to provide an option for "explicit" queue time.  Instead of calculating time available to partners / bands based on band percentages, classical, rollover time, etc (see `QueueTimeExtractor` and `PartnerTimeCalc`), the idea is that the time per partner per band will be explicitly provided by the user.

At the moment, I've just taken the existing `QueueTime` class and made it a `sealed trait` with two implementations.  The first being the old "derived" queue time calculation and the second a new `ExplicitQueueTime` option that is still unused.  To make it work, the explicit queue values need to be added to the Java persistence model and then extracted in the queue service in order to feed it as a parameter to the queue engine.  This will mean a different `QueueTimeExtractor` implementation and removing a lot of parameters that are no longer needed.

__CYA Note__.  The queue engine was my first attempt to write Scala or do anything in a functional style for that matter.  I think it was done with Scala 2.7 and definitely without Scalaz.  It is embarrassing.  I know that a lot of improvements could be made with time and a bit of Scalaz.