### PR TITLE
REL-3145: ITAC emails must be adjusted to explain time allocation breakdown

### DIFF
--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
@@ -35,6 +35,9 @@ public abstract class Template {
                 { "@PROG_TITLE@",           "$values.progTitle"},
                 { "@PROG_KEY@",             "$values.progKey"},
                 { "@QUEUE_BAND@",           "$values.queueBand"},
+                { "@TOTAL_TIME@",           "$values.totalTime"},
+                { "@PROG_TIME@",            "$values.programTime"},
+                { "@PARTNER_TIME@",         "$values.partnerTime"},
                 { "@TIME_AWARDED@",         "$values.timeAwarded"}
         };
     }

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
@@ -35,7 +35,6 @@ public abstract class Template {
                 { "@PROG_TITLE@",           "$values.progTitle"},
                 { "@PROG_KEY@",             "$values.progKey"},
                 { "@QUEUE_BAND@",           "$values.queueBand"},
-                { "@TOTAL_TIME@",           "$values.totalTime"},
                 { "@PROG_TIME@",            "$values.programTime"},
                 { "@PARTNER_TIME@",         "$values.partnerTime"},
                 { "@TIME_AWARDED@",         "$values.timeAwarded"}

--- a/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
@@ -650,5 +650,13 @@ public class EmailsHibernateService implements IEmailsService {
         public String getTimeAwarded() {
             return timeAwarded;
         }
+
+        public String getProgramTime() {
+            return progTime;
+        }
+
+        public String getPartnerTime() {
+            return partnerTime;
+        }
     }
 }

--- a/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
@@ -544,8 +544,10 @@ public class EmailsHibernateService implements IEmailsService {
                 TimeAmount progTime = new TimeAmount(0, TimeUnit.HR);
                 TimeAmount partTime = new TimeAmount(0, TimeUnit.HR);
                 for (Observation o : proposal.getPhaseIProposal().getObservations()) {
-                    progTime = progTime.sum(o.getProgTime());
-                    partTime = partTime.sum(o.getPartTime());
+                    if (o.getActive()) {
+                      progTime = progTime.sum(o.getProgTime());
+                      partTime = partTime.sum(o.getPartTime());
+                    }
                 }
                 // Total time for program and partner
                 TimeAmount sumTime = progTime.sum(partTime);

--- a/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
@@ -476,7 +476,6 @@ public class EmailsHibernateService implements IEmailsService {
         private String progTitle = N_A;
         private String progKey = N_A;
         private String queueBand = N_A;
-        private String totalTime = N_A;
         private String progTime = N_A;
         private String partnerTime = N_A;
         private String timeAwarded = N_A;
@@ -541,7 +540,6 @@ public class EmailsHibernateService implements IEmailsService {
 
             // We'll match the total time to the time awarded and scale
             // the program and partner time to fit
-            this.totalTime = this.timeAwarded;
             if (successful) {
                 TimeAmount progTime = new TimeAmount(0, TimeUnit.HR);
                 TimeAmount partTime = new TimeAmount(0, TimeUnit.HR);

--- a/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
@@ -550,7 +550,8 @@ public class EmailsHibernateService implements IEmailsService {
                 // Total time for program and partner
                 TimeAmount sumTime = progTime.sum(partTime);
                 // Scale factor with respect to the awarded time
-                BigDecimal factor = itac.getAccept().getAward().getValueInHours().divide(sumTime.getValueInHours());
+                BigDecimal factor = itac.getAccept().getAward().getValueInHours().divide(sumTime.getValueInHours(), BigDecimal.ROUND_CEILING);
+                // Scale the prog and program time
                 this.progTime = new TimeAmount(progTime.getValueInHours().multiply(factor), TimeUnit.HR).toPrettyString();
                 this.partnerTime = new TimeAmount(partTime.getValueInHours().multiply(factor), TimeUnit.HR).toPrettyString();
             } else {

--- a/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
@@ -544,14 +544,9 @@ public class EmailsHibernateService implements IEmailsService {
 
             // Find the correct set of observations. Note that they return the active observations already
             List<Observation> bandObservations = null;
-            if (banding != null) {
-              if (banding.getBand() == ScienceBand.BAND_THREE) {
-                bandObservations = proposal.getPhaseIProposal().getBand3Observations();
-              } else {
-                bandObservations = proposal.getPhaseIProposal().getBand1Band2ActiveObservations();
-              }
+            if (banding != null && banding.getBand() == ScienceBand.BAND_THREE) {
+              bandObservations = proposal.getPhaseIProposal().getBand3Observations();
             } else {
-              // Let's assume it is classical
               bandObservations = proposal.getPhaseIProposal().getBand1Band2ActiveObservations();
             }
             if (successful) {

--- a/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ObservationIoTest.scala
+++ b/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ObservationIoTest.scala
@@ -109,7 +109,7 @@ class ObservationIoTest {
           Some(conditions),
           Some(siderealTarget),
           im.Band.BAND_1_2,
-          Some(oneHour)
+          Some(\/.right(oneHour))
         )
       }
     }
@@ -123,7 +123,7 @@ class ObservationIoTest {
           None,
           Some(siderealTarget),
           im.Band.BAND_1_2,
-          Some(oneHour)
+          Some(\/.right(oneHour))
         )
       }
     }
@@ -137,7 +137,7 @@ class ObservationIoTest {
           Some(conditions),
           None,
           im.Band.BAND_1_2,
-          Some(oneHour)
+          Some(\/.right(oneHour))
         )
       }
     }
@@ -203,7 +203,7 @@ class ObservationIoTest {
         Some(conditions),
         Some(siderealTarget),
         im.Band.BAND_1_2,
-        Some(oneHour)
+        Some(\/.right(oneHour))
       )
       override def observations = List(observation, nifsObservation)
     }
@@ -229,7 +229,7 @@ class ObservationIoTest {
         Some(conditions),
         Some(siderealTarget),
         im.Band.BAND_3,
-        Some(oneHour)
+        Some(\/.right(oneHour))
       )
       override def observations = List(observation, b3Observation)
     }
@@ -253,7 +253,7 @@ class ObservationIoTest {
         Some(conditions),
         Some(siderealTarget),
         im.Band.BAND_1_2,
-        Some(twoHour)
+        Some(\/.right(twoHour))
       )
 
       private def b3Observation = im.Observation(
@@ -261,7 +261,7 @@ class ObservationIoTest {
         Some(conditions),
         Some(siderealTarget),
         im.Band.BAND_3,
-        Some(oneHour)
+        Some(\/.right(oneHour))
       )
 
       private def nifsObservation = im.Observation(
@@ -269,7 +269,7 @@ class ObservationIoTest {
         Some(conditions),
         Some(siderealTarget),
         im.Band.BAND_1_2,
-        Some(oneHour)
+        Some(\/.right(oneHour))
       )
 
       override def observations = List(observation, b3Observation, observation2, nifsObservation)

--- a/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalFixture.scala
+++ b/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalFixture.scala
@@ -37,7 +37,7 @@ class ProposalFixture {
     Some(conditions),
     Some(siderealTarget),
     im.Band.BAND_1_2,
-    Some(oneHour)
+    Some(\/.right(oneHour))
   )
   def observations   = List(observation)
 

--- a/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalIoTest.scala
+++ b/queue-engine/qengine-p1-io/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalIoTest.scala
@@ -147,7 +147,7 @@ class ProposalIoTest {
         Some(conditions),
         Some(siderealTarget),
         im.Band.BAND_1_2,
-        Some(oneHour)
+        Some(\/.right(oneHour))
       )
       override def observations = List(observation, nifsObservation)
     }


### PR DESCRIPTION
This PR adds variables to the emails templates. I'm opening this for discussion but won't merge it until it can be validated