### PR TITLE
REL-3145: ITAC emails must be adjusted to explain time allocation breakdown

### DIFF
--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/TimeAmount.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/TimeAmount.java
@@ -18,6 +18,8 @@ public class TimeAmount implements Comparable {
     protected TimeUnit units;
     private static final double EQUALS_TOLERANCE = 0.00001d;
 
+    private static final double HOURS_TO_MILLIS = 60 * 60 * 10000;
+
     public TimeAmount(final BigDecimal value, final TimeUnit units) {
         this.value = value;
         this.units = units;
@@ -29,6 +31,10 @@ public class TimeAmount implements Comparable {
 
     public TimeAmount(final double value, final TimeUnit units) {
         this(new BigDecimal(value), units);
+    }
+
+    public static TimeAmount fromMillis(double value) {
+        return new TimeAmount(value / HOURS_TO_MILLIS, TimeUnit.HR);
     }
 
     public TimeAmount(final edu.gemini.model.p1.mutable.TimeAmount timeAmount) {
@@ -135,6 +141,10 @@ public class TimeAmount implements Comparable {
 
     public double getDoubleValueInHours() {
         return convertTo(TimeUnit.HR).getDoubleValue();
+    }
+
+    public double getDoubleValueInMillis() {
+        return convertTo(TimeUnit.HR).getDoubleValue() * HOURS_TO_MILLIS;
     }
 
     @Override

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/TimeAmount.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/TimeAmount.java
@@ -7,6 +7,7 @@ import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import java.math.BigDecimal;
+import java.time.Duration;
 
 @Embeddable
 public class TimeAmount implements Comparable {
@@ -18,7 +19,7 @@ public class TimeAmount implements Comparable {
     protected TimeUnit units;
     private static final double EQUALS_TOLERANCE = 0.00001d;
 
-    private static final double HOURS_TO_MILLIS = 60 * 60 * 10000;
+    private static final double HOURS_TO_MILLIS = Duration.ofHours(1).toMillis();
 
     public TimeAmount(final BigDecimal value, final TimeUnit units) {
         this.value = value;

--- a/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
@@ -544,7 +544,7 @@ public class EmailsHibernateService implements IEmailsService {
 
             // Find the correct set of observations. Note that they return the active observations already
             List<Observation> bandObservations = null;
-            if (banding != null && banding.getBand() == ScienceBand.BAND_THREE) {
+            if (banding != null && banding.getBand().equals(ScienceBand.BAND_THREE)) {
               bandObservations = proposal.getPhaseIProposal().getBand3Observations();
             } else {
               bandObservations = proposal.getPhaseIProposal().getBand1Band2ActiveObservations();
@@ -559,10 +559,10 @@ public class EmailsHibernateService implements IEmailsService {
                 // Total time for program and partner
                 TimeAmount sumTime = progTime.sum(partTime);
                 // Scale factor with respect to the awarded time
-                BigDecimal factor = itac.getAccept().getAward().getValueInHours().divide(sumTime.getValueInHours(), BigDecimal.ROUND_CEILING);
+                double ratio = progTime.getValueInHours().doubleValue() / sumTime.getValueInHours().doubleValue();
                 // Scale the prog and program time
-                this.progTime = new TimeAmount(progTime.getValueInHours().multiply(factor), TimeUnit.HR).toPrettyString();
-                this.partnerTime = new TimeAmount(partTime.getValueInHours().multiply(factor), TimeUnit.HR).toPrettyString();
+                this.progTime = TimeAmount.fromMillis(itac.getAccept().getAward().getDoubleValueInMillis() * ratio).toPrettyString();
+                this.partnerTime = TimeAmount.fromMillis(itac.getAccept().getAward().getDoubleValueInMillis() * (1.0 - ratio)).toPrettyString();
             } else {
                 this.partnerTime = "0.0 " + ntacExtension.getRequest().getTime().getUnits();
                 this.progTime = "0.0 " + ntacExtension.getRequest().getTime().getUnits();
@@ -572,6 +572,7 @@ public class EmailsHibernateService implements IEmailsService {
             // emails will be concatenated to a list separated by semi-colons
             this.piMail = pi.getEmail();
             this.piName = pi.getFirstName() + " " + pi.getLastName();
+
             if (doc.getTitle() != null) {
                 this.progTitle = doc.getTitle();
             }


### PR DESCRIPTION
This fixes differences between the OT and ITAC on the way the program and partner time are calculated