### PR TITLE
Update to p1-model-2018A.1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 script:
-  - mvn install -U -DskipTests -B
+  - mvn -U clean install -DskipTests -B
   - mvn test -B --projects itac-configuration,itac-web,queue-engine,queue-service
 jdk:
   - oraclejdk8

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/submission/ExchangeSubmission.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/submission/ExchangeSubmission.java
@@ -72,8 +72,8 @@ public class ExchangeSubmission extends PartnerSubmission {
             return ExchangePartner.KECK;
         } else if (partner.getPartnerCountryKey().equals(ExchangePartner.SUBARU.name())) {
             return ExchangePartner.SUBARU;
-        } else if (partner.getPartnerCountryKey().equals(ExchangePartner.CFHT.name())) {
-            return ExchangePartner.CFHT;
+        } else if (partner.getPartnerCountryKey().equals(ExchangePartner.CFH.name())) {
+            return ExchangePartner.CFH;
         } else {
             throw new IllegalArgumentException("not a valid exchange partner " + partner.getName());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <unitils.version>3.1</unitils.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.httpclient.version>3.1</commons.httpclient.version>
-        <ocs.model.p1.version>2017102.1.0</ocs.model.p1.version>
+        <ocs.model.p1.version>2018001.1.0</ocs.model.p1.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
Technically, I think the p1-model may be `2018A.1.4.0` but we can upgrade to the final version once the ocs is really ready for release.

I also bumped the ITAC version but I don't know if that version is correct.