### PR TITLE
Add Alopeke blueprint

### DIFF
--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Instrument.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Instrument.java
@@ -22,6 +22,7 @@ public enum Instrument {
     GPI("GPI", Site.SOUTH),
     DSSI_GN("Dssi Gemini North", Site.NORTH),
     DSSI_GS("Dssi Gemini South", Site.SOUTH),
+    ALOPEKE("Alopeke", Site.NORTH),
     TEXES_GN("Texes Gemini North", Site.NORTH),
     TEXES_GS("Texes Gemini South", Site.SOUTH),
     VISITORGS("Visitor Gemini South", Site.SOUTH),

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
@@ -6,6 +6,7 @@ import edu.gemini.tac.persistence.IValidateable;
 import edu.gemini.tac.persistence.Site;
 import edu.gemini.tac.persistence.phase1.Instrument;
 import edu.gemini.tac.persistence.phase1.Observation;
+import edu.gemini.tac.persistence.phase1.blueprint.alopeke.AlopekeBlueprint;
 import edu.gemini.tac.persistence.phase1.blueprint.gmoss.GmosSBlueprintLongSlit;
 import edu.gemini.tac.persistence.phase1.blueprint.dssi.DssiBlueprint;
 import edu.gemini.tac.persistence.phase1.blueprint.visitor.VisitorGNBlueprint;
@@ -97,6 +98,9 @@ import java.util.Set;
         @NamedQuery(name = "BlueprintBase.resourcesDssiBlueprint",
                 query = "from DssiBlueprint b where b in (:blueprints)"
         ),
+        @NamedQuery(name = "BlueprintBase.resourcesAlopekeBlueprint",
+                query = "from AlopekeBlueprint b where b in (:blueprints)"
+        ),
         @NamedQuery(name = "BlueprintBase.resourcesGpiBlueprint",
                 query = "from GpiBlueprint b where b in (:blueprints)"
         ),
@@ -137,6 +141,7 @@ abstract public class BlueprintBase implements IValidateable, Serializable {
         "BlueprintBase.resourcesGpiBlueprint",
         "BlueprintBase.resourcesPhoenixBlueprint",
         "BlueprintBase.resourcesDssiBlueprint",
+        "BlueprintBase.resourcesAlopekeBlueprint",
         "BlueprintBase.resourcesTexesBlueprint",
         "BlueprintBase.resourcesVisitorGSBlueprint",
         "BlueprintBase.resourcesVisitorGNBlueprint",
@@ -271,6 +276,8 @@ abstract public class BlueprintBase implements IValidateable, Serializable {
             return convertPhoenixBlueprint((PhoenixBlueprintChoice) blueprintChoice);
         } else if (blueprintChoice instanceof DssiBlueprintChoice) {
             return convertDssiBlueprint((DssiBlueprintChoice) blueprintChoice);
+        } else if (blueprintChoice instanceof AlopekeBlueprintChoice) {
+            return convertAlopekeBlueprint((AlopekeBlueprintChoice) blueprintChoice);
         } else if (blueprintChoice instanceof TexesBlueprintChoice) {
             return convertTexesBlueprint((TexesBlueprintChoice) blueprintChoice);
         } else if (blueprintChoice instanceof VisitorBlueprintChoice) {
@@ -415,6 +422,14 @@ abstract public class BlueprintBase implements IValidateable, Serializable {
     private static BlueprintBase convertDssiBlueprint(DssiBlueprintChoice choice) {
         if (choice.getDssi() != null) {
             return new DssiBlueprint(choice.getDssi());
+        } else {
+            throw new IllegalArgumentException(NO_FACTORY_FOR + choice.toString());
+        }
+    }
+
+    private static BlueprintBase convertAlopekeBlueprint(AlopekeBlueprintChoice choice) {
+        if (choice.getAlopeke() != null) {
+            return new AlopekeBlueprint(choice.getAlopeke());
         } else {
             throw new IllegalArgumentException(NO_FACTORY_FOR + choice.toString());
         }

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/alopeke/AlopekeBlueprint.scala
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/alopeke/AlopekeBlueprint.scala
@@ -1,0 +1,49 @@
+package edu.gemini.tac.persistence.phase1.blueprint.alopeke
+
+import javax.persistence._
+
+import edu.gemini.model.p1.mutable.AlopekeMode
+
+import scala.collection.JavaConverters._
+import edu.gemini.tac.persistence.phase1.blueprint.{BlueprintBase, BlueprintPair}
+import edu.gemini.tac.persistence.phase1.Instrument
+
+@Entity
+@DiscriminatorValue("AlopekeBlueprint")
+class AlopekeBlueprint(b: edu.gemini.model.p1.mutable.AlopekeBlueprint) extends BlueprintBase(b.getId, b.getName, Instrument.ALOPEKE) {
+  @Enumerated(EnumType.STRING)
+  @Column(name = "visitor_site")
+  val mode: AlopekeMode = b.getMode
+
+  def this() = this(new edu.gemini.model.p1.mutable.AlopekeBlueprint())
+
+  override def getDisplayAdaptiveOptics = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayCamera = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayFocalPlaneUnit = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayDisperser = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayFilter = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayOther = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def toMutable:BlueprintPair = {
+      val choice = new edu.gemini.model.p1.mutable.AlopekeBlueprintChoice
+      val mBlueprint = new edu.gemini.model.p1.mutable.AlopekeBlueprint
+      choice.setAlopeke(mBlueprint)
+
+      mBlueprint.setId(getBlueprintId)
+      mBlueprint.setName(getName)
+      mBlueprint.setMode(mode)
+
+      new BlueprintPair(choice, mBlueprint)
+    }
+
+  override def getComplementaryInstrumentBlueprint = throw new RuntimeException("Switching sites has no meaning for Alopeke blueprints.")
+
+  override def getResourcesByCategory = Map[String, java.util.Set[String]]("mode" -> Set[String](mode.value()).asJava).asJava
+
+  override def isMOS: Boolean = false
+}

--- a/phase1-data/src/main/resources/sessionFactory.xml
+++ b/phase1-data/src/main/resources/sessionFactory.xml
@@ -109,6 +109,8 @@
 
                 <value>edu.gemini.tac.persistence.phase1.blueprint.dssi.DssiBlueprint</value>
 
+                <value>edu.gemini.tac.persistence.phase1.blueprint.alopeke.AlopekeBlueprint</value>
+
                 <value>edu.gemini.tac.persistence.phase1.blueprint.texes.TexesBlueprint</value>
 
                 <value>edu.gemini.tac.persistence.phase1.blueprint.trecs.TrecsBlueprintImaging</value>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <unitils.version>3.1</unitils.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.httpclient.version>3.1</commons.httpclient.version>
-        <ocs.model.p1.version>2018001.1.0</ocs.model.p1.version>
+        <ocs.model.p1.version>2018102.1.0</ocs.model.p1.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
This changes were done by imitating what it was already there for DSSI, with the additions of 2 modes for Alopeke.

I manually tweaked some proposals from previous semester and changed the blueprints to Alopeke in both modes. I could import it and export those proposals without any issues, but we should at some point test it with real Alopeke proposals.

I didn't change anything in the UI, I could see the Alopeke instrument and the mode as it's coming in the XML but I don't know if that's good enough.