### PR TITLE
Add Alopeke mode to blueprint display

### DIFF
--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/alopeke/AlopekeBlueprint.scala
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/alopeke/AlopekeBlueprint.scala
@@ -17,6 +17,8 @@ class AlopekeBlueprint(b: edu.gemini.model.p1.mutable.AlopekeBlueprint) extends 
 
   def this() = this(new edu.gemini.model.p1.mutable.AlopekeBlueprint())
 
+  override def getDisplay = name
+
   override def getDisplayAdaptiveOptics = BlueprintBase.DISPLAY_NOT_APPLICABLE
 
   override def getDisplayCamera = BlueprintBase.DISPLAY_NOT_APPLICABLE

--- a/queue-engine/qengine-p1-io/src/main/scala/edu/gemini/tac/qengine/p1/io/ObservationIo.scala
+++ b/queue-engine/qengine-p1-io/src/main/scala/edu/gemini/tac/qengine/p1/io/ObservationIo.scala
@@ -32,6 +32,7 @@ object ObservationIo {
     def site(p1Obs: im.Observation): Site = {
       val imSite = p1Obs.blueprint.map {
         case d: im.DssiBlueprint       => d.site
+        case a: im.AlopekeBlueprint    => a.site
         case t: im.TexesBlueprint      => t.site
         case p: im.PhoenixBlueprint    => p.site
         case v: im.VisitorBlueprint    => v.site


### PR DESCRIPTION
Previously both modes were displayed as just `Alopeke`, now it also shows the mode string representation from the p1 model: `Alopeke Wide Field (0.0725"/pix, 60" FoV)`.