### PR TITLE
Prepend Program ID to subject emails

### DIFF
--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
@@ -135,6 +135,13 @@ public abstract class Template {
         return velocityTemplate;
     }
 
+    public String getVelocityTemplate(String template) {
+        if (velocityTemplate == null) {
+            velocityTemplate = translateGeminiSpeakToVelocityTalk(template);
+        }
+        return velocityTemplate;
+    }
+
     public String getDescription() {
         return description;
     }

--- a/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
+++ b/phase1-services/src/main/java/edu/gemini/tac/service/EmailsHibernateService.java
@@ -417,7 +417,7 @@ public class EmailsHibernateService implements IEmailsService {
         email.setBanding(banding);
         email.setProposal(proposal);
         email.setAddress(address);
-        email.setSubject(template.getSubject());
+        email.setSubject(fillCustomTemplate(template, template.getSubject(), values));
         email.setContent(fillTemplate(template, values));
         email.setDescription(template.getDescription());
         if (ccRecipients != null)
@@ -439,9 +439,14 @@ public class EmailsHibernateService implements IEmailsService {
         return templatesMap;
     }
 
-    private String fillTemplate(Template template, VariableValues values) {
+    private String fillCustomTemplate(Template template, String ctemplate, VariableValues values) {
         Writer writer = new StringWriter(5000);
-        Reader reader = new StringReader(template.getVelocityTemplate());
+        Reader reader;
+        if (ctemplate != null) {
+            reader = new StringReader(template.getVelocityTemplate(ctemplate));
+        } else {
+            reader = new StringReader(template.getVelocityTemplate());
+        }
 
         VelocityContext context = new VelocityContext();
         context.put("values", values);
@@ -453,6 +458,10 @@ public class EmailsHibernateService implements IEmailsService {
         }
 
         return writer.toString();
+    }
+
+    private String fillTemplate(Template template, VariableValues values) {
+        return fillCustomTemplate(template, null, values);
     }
 
     // simple java bean used to pass variable values to velocity engine


### PR DESCRIPTION
The proper way to fix it would be by enabling template interpolation for the subject as in the body of the email.

The limitation of this method is that it will always prepend the ID to the subject even if you try to change the format of the subject from the ITAC web interface.

I already consulted if this limitation would be alright with Lindsay and Rodrigo and after testing manually on their on they are saying they are fine with it.