### PR TITLE
Regenerate email templates every time they are accessed

### DIFF
--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/emails/Template.java
@@ -129,17 +129,11 @@ public abstract class Template {
     }
 
     public String getVelocityTemplate() {
-        if (velocityTemplate == null) {
-            velocityTemplate = translateGeminiSpeakToVelocityTalk(geminiTemplate);
-        }
-        return velocityTemplate;
+	    return translateGeminiSpeakToVelocityTalk(geminiTemplate);
     }
 
     public String getVelocityTemplate(String template) {
-        if (velocityTemplate == null) {
-            velocityTemplate = translateGeminiSpeakToVelocityTalk(template);
-        }
-        return velocityTemplate;
+	    return translateGeminiSpeakToVelocityTalk(template);
     }
 
     public String getDescription() {


### PR DESCRIPTION
This makes it possible to use different templates for email body and subject.

This may make the process of generating emails slower but we didn't notice it, subjectively, much slower than before.