### PR TITLE
ITAC 2019B update

### DIFF
--- a/itac-configuration/pom.xml
+++ b/itac-configuration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>tacUmbrella</artifactId>
         <groupId>edu.gemini.tac</groupId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/itac-web/pom.xml
+++ b/itac-web/pom.xml
@@ -5,13 +5,13 @@
     <groupId>edu.gemini.tac</groupId>
     <artifactId>itac-web</artifactId>
     <packaging>war</packaging>
-    <version>2018.2.2</version>
+    <version>2019.2.1</version>
     <name>TAC web application</name>
 
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>tacUmbrella</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <build>
@@ -290,7 +290,7 @@
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-services</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
 
         <!-- provide access to actual implementations of phase2 services -->
@@ -361,22 +361,22 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qservice-api</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qservice-impl</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-api</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-impl</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
 
         <dependency>
@@ -415,7 +415,7 @@
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/phase1-data/pom.xml
+++ b/phase1-data/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>tacUmbrella</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <prerequisites>
@@ -271,7 +271,7 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>itac-configuration</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/phase1-services/pom.xml
+++ b/phase1-services/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>tacUmbrella</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <prerequisites>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>
@@ -217,14 +217,14 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>itac-configuration</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.gemini.tac</groupId>
     <artifactId>tacUmbrella</artifactId>
-    <version>2018.2.2</version>
+    <version>2019.2.1</version>
     <name>TAC umbrella project</name>
     <url>http://maven.apache.org</url>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <unitils.version>3.1</unitils.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.httpclient.version>3.1</commons.httpclient.version>
-        <ocs.model.p1.version>2018102.1.0</ocs.model.p1.version>
+        <ocs.model.p1.version>2019102.1.0</ocs.model.p1.version>
     </properties>
     <repositories>
         <repository>

--- a/queue-engine/pom.xml
+++ b/queue-engine/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>tacUmbrella</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/queue-engine/qengine-api/pom.xml
+++ b/queue-engine/qengine-api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>queue-engine</artifactId>
         <groupId>edu.gemini.tac</groupId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -33,27 +33,27 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-util</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p2</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-log</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
     </dependencies>
 

--- a/queue-engine/qengine-app/pom.xml
+++ b/queue-engine/qengine-app/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>queue-engine</artifactId>
         <groupId>edu.gemini.tac</groupId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -30,42 +30,42 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-util</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1-io</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-api</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-impl</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-log</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-skycalc</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-services</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>

--- a/queue-engine/qengine-ctx/pom.xml
+++ b/queue-engine/qengine-ctx/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>queue-engine</artifactId>
         <groupId>edu.gemini.tac</groupId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
 
@@ -26,7 +26,7 @@
          <dependency>
              <groupId>edu.gemini.tac</groupId>
              <artifactId>qengine-util</artifactId>
-             <version>2018.2.2</version>
+             <version>2019.2.1</version>
          </dependency>
     </dependencies>
 </project>

--- a/queue-engine/qengine-impl/pom.xml
+++ b/queue-engine/qengine-impl/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-engine</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -29,27 +29,27 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-util</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-api</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-log</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/queue-engine/qengine-log/pom.xml
+++ b/queue-engine/qengine-log/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>queue-engine</artifactId>
         <groupId>edu.gemini.tac</groupId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -25,17 +25,17 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-util</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
          <dependency>
             <groupId>log4j</groupId>

--- a/queue-engine/qengine-p1-io/pom.xml
+++ b/queue-engine/qengine-p1-io/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-engine</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -48,17 +48,17 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-util</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>

--- a/queue-engine/qengine-p1/pom.xml
+++ b/queue-engine/qengine-p1/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-engine</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-util</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
     </dependencies>
 

--- a/queue-engine/qengine-p2/pom.xml
+++ b/queue-engine/qengine-p2/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-engine</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -24,17 +24,17 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-util</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
     </dependencies>
 

--- a/queue-engine/qengine-skycalc/pom.xml
+++ b/queue-engine/qengine-skycalc/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-engine</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>gemini-nocs</groupId>

--- a/queue-engine/qengine-util/pom.xml
+++ b/queue-engine/qengine-util/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>queue-engine</artifactId>
         <groupId>edu.gemini.tac</groupId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/queue-service/pom.xml
+++ b/queue-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>tacUmbrella</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>pom</packaging>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/queue-service/ps-conversion-test-support/pom.xml
+++ b/queue-service/ps-conversion-test-support/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-service</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -23,18 +23,18 @@
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-services</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
 
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
     </dependencies>
 

--- a/queue-service/ps-conversion/pom.xml
+++ b/queue-service/ps-conversion/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-service</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -24,46 +24,46 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>ps-conversion-test-support</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-services</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
 
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-api</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-ctx</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1-io</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <!-- Test-only dependencies -->
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>itac-configuration</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/queue-service/qservice-api/pom.xml
+++ b/queue-service/qservice-api/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-service</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-services</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
     </dependencies>
 

--- a/queue-service/qservice-impl/pom.xml
+++ b/queue-service/qservice-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>edu.gemini.tac</groupId>
         <artifactId>queue-service</artifactId>
-        <version>2018.2.2</version>
+        <version>2019.2.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -41,50 +41,50 @@
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>ps-conversion</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-p1-io</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-impl</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qservice-api</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>qengine-skycalc</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-data</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
         <dependency>
             <groupId>edu.gemini</groupId>
             <artifactId>phase1-services</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
         </dependency>
 
         <!-- additional dependencies for testing -->
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>ps-conversion-test-support</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>edu.gemini.tac</groupId>
             <artifactId>itac-configuration</artifactId>
-            <version>2018.2.2</version>
+            <version>2019.2.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This updates to ITAC 2019B, due to a change in the P1 model.

1. To make this change, I needed to fork:

https://github.com/gemini-hlsw/maven-repo

2. Then, follow the instructions in:

https://github.com/gemini-hlsw/maven-repo

to change the OCS `build.sbt` file. Make sure `OCS_REPO` points to the `mvn-repo/releases` directory.

3. Add credentials to `~/.sbt/0.13/artifactory.sbt` to be:

`credentials += Credentials(Path.userHome / ".sbt" / ".credentials")`

4. Create the credentials file, which should have form:

```
realm=Artifactory Realm
host=sbfosxdev-mp1.cl.gemini.edu
user=sraaphorst
password=<insert software password here>
```

5. In OCS, kick off `sbt`, and perform:

```
project app_bundle_edu_gemini_model_p1
publish
project app_bundle_edu_spmodel_core
publish
```

6. This will copy the files into `mvn-repo/releases`. Commit and make a PR.

7. Finally, go through the `pom` files in ITAC and change the versions as necessary. One to look out for is:

`<ocs.model.p1.version>2018102.1.0</ocs.model.p1.version>`

8. Lastly, test your changes by running:

`mvn -U -DskipTests clean install`

and if that works, you have muddled through poorly documented arcane knowledge that was not meant for mere mortals.