### PR TITLE
REL-3456: Adding Zorro to ITAC

### DIFF
--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Instrument.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/Instrument.java
@@ -23,6 +23,7 @@ public enum Instrument {
     DSSI_GN("Dssi Gemini North", Site.NORTH),
     DSSI_GS("Dssi Gemini South", Site.SOUTH),
     ALOPEKE("Alopeke", Site.NORTH),
+    ZORRO("Zorro", Site.SOUTH),
     TEXES_GN("Texes Gemini North", Site.NORTH),
     TEXES_GS("Texes Gemini South", Site.SOUTH),
     VISITORGS("Visitor Gemini South", Site.SOUTH),

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
@@ -102,8 +102,8 @@ import java.util.Set;
         @NamedQuery(name = "BlueprintBase.resourcesAlopekeBlueprint",
                 query = "from AlopekeBlueprint b where b in (:blueprints)"
         ),
-        @NamedQuery(name = "BlueprintBase.resourceZorroBlueprint",
-                query = "from ZorroBlueprint b where b in (:blueprnts)"
+        @NamedQuery(name = "BlueprintBase.resourcesZorroBlueprint",
+                query = "from ZorroBlueprint b where b in (:blueprints)"
         ),
         @NamedQuery(name = "BlueprintBase.resourcesGpiBlueprint",
                 query = "from GpiBlueprint b where b in (:blueprints)"

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
@@ -104,7 +104,7 @@ import java.util.Set;
         ),
         @NamedQuery(name = "BlueprintBase.resourceZorroBlueprint",
                 query = "from ZorroBlueprint b where b in (:blueprnts)"
-        )
+        ),
         @NamedQuery(name = "BlueprintBase.resourcesGpiBlueprint",
                 query = "from GpiBlueprint b where b in (:blueprints)"
         ),
@@ -444,7 +444,7 @@ abstract public class BlueprintBase implements IValidateable, Serializable {
 
     private static BlueprintBase convertZorroBlueprint(ZorroBlueprintChoice choice) {
         if (choice.getZorro() != null) {
-            return new ZorroBlueprint((choice.getZorro());
+            return new ZorroBlueprint(choice.getZorro());
         } else {
             throw new IllegalArgumentException(NO_FACTORY_FOR + choice.toString());
         }

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/BlueprintBase.java
@@ -7,6 +7,7 @@ import edu.gemini.tac.persistence.Site;
 import edu.gemini.tac.persistence.phase1.Instrument;
 import edu.gemini.tac.persistence.phase1.Observation;
 import edu.gemini.tac.persistence.phase1.blueprint.alopeke.AlopekeBlueprint;
+import edu.gemini.tac.persistence.phase1.blueprint.zorro.ZorroBlueprint;
 import edu.gemini.tac.persistence.phase1.blueprint.gmoss.GmosSBlueprintLongSlit;
 import edu.gemini.tac.persistence.phase1.blueprint.dssi.DssiBlueprint;
 import edu.gemini.tac.persistence.phase1.blueprint.visitor.VisitorGNBlueprint;
@@ -101,6 +102,9 @@ import java.util.Set;
         @NamedQuery(name = "BlueprintBase.resourcesAlopekeBlueprint",
                 query = "from AlopekeBlueprint b where b in (:blueprints)"
         ),
+        @NamedQuery(name = "BlueprintBase.resourceZorroBlueprint",
+                query = "from ZorroBlueprint b where b in (:blueprnts)"
+        )
         @NamedQuery(name = "BlueprintBase.resourcesGpiBlueprint",
                 query = "from GpiBlueprint b where b in (:blueprints)"
         ),
@@ -142,6 +146,7 @@ abstract public class BlueprintBase implements IValidateable, Serializable {
         "BlueprintBase.resourcesPhoenixBlueprint",
         "BlueprintBase.resourcesDssiBlueprint",
         "BlueprintBase.resourcesAlopekeBlueprint",
+        "BlueprintBase.resourcesZorroBlueprint",
         "BlueprintBase.resourcesTexesBlueprint",
         "BlueprintBase.resourcesVisitorGSBlueprint",
         "BlueprintBase.resourcesVisitorGNBlueprint",
@@ -278,6 +283,8 @@ abstract public class BlueprintBase implements IValidateable, Serializable {
             return convertDssiBlueprint((DssiBlueprintChoice) blueprintChoice);
         } else if (blueprintChoice instanceof AlopekeBlueprintChoice) {
             return convertAlopekeBlueprint((AlopekeBlueprintChoice) blueprintChoice);
+        } else if (blueprintChoice instanceof ZorroBlueprintChoice) {
+            return convertZorroBlueprint((ZorroBlueprintChoice) blueprintChoice);
         } else if (blueprintChoice instanceof TexesBlueprintChoice) {
             return convertTexesBlueprint((TexesBlueprintChoice) blueprintChoice);
         } else if (blueprintChoice instanceof VisitorBlueprintChoice) {
@@ -434,6 +441,14 @@ abstract public class BlueprintBase implements IValidateable, Serializable {
             throw new IllegalArgumentException(NO_FACTORY_FOR + choice.toString());
         }
     }
+
+    private static BlueprintBase convertZorroBlueprint(ZorroBlueprintChoice choice) {
+        if (choice.getZorro() != null) {
+            return new ZorroBlueprint((choice.getZorro());
+        } else {
+            throw new IllegalArgumentException(NO_FACTORY_FOR + choice.toString());
+        }
+     }
 
     private static BlueprintBase convertVisitorBlueprint(VisitorBlueprintChoice choice) {
         if (choice.getVisitor() != null) {

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/alopeke/AlopekeBlueprint.scala
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/alopeke/AlopekeBlueprint.scala
@@ -39,6 +39,7 @@ class AlopekeBlueprint(b: edu.gemini.model.p1.mutable.AlopekeBlueprint) extends 
       mBlueprint.setId(getBlueprintId)
       mBlueprint.setName(getName)
       mBlueprint.setMode(mode)
+      mBlueprint.setVisitor(true)
 
       new BlueprintPair(choice, mBlueprint)
     }

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/zorro/ZorroBlueprint.scala
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/zorro/ZorroBlueprint.scala
@@ -1,0 +1,51 @@
+package edu.gemini.tac.persistence.phase1.blueprint.zorro
+
+import javax.persistence._
+
+import edu.gemini.model.p1.mutable.ZorroMode
+
+import scala.collection.JavaConverters._
+import edu.gemini.tac.persistence.phase1.blueprint.{BlueprintBase, BlueprintPair}
+import edu.gemini.tac.persistence.phase1.Instrument
+
+@Entity
+@DiscriminatorValue("ZorroBlueprint")
+class ZorroBlueprint(b: edu.gemini.model.p1.mutable.ZorroBlueprint) extends BlueprintBase(b.getId, b.getName, Instrument.ZORRO) {
+  @Enumerated(EnumType.STRING)
+  @Column(name = "visitor_site")
+  val mode: ZorroMode = b.getMode
+
+  def this() = this(new edu.gemini.model.p1.mutable.ZorroBlueprint())
+
+  override def getDisplay = name
+
+  override def getDisplayAdaptiveOptics = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayCamera = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayFocalPlaneUnit = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayDisperser = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayFilter = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def getDisplayOther = BlueprintBase.DISPLAY_NOT_APPLICABLE
+
+  override def toMutable:BlueprintPair = {
+    val choice = new edu.gemini.model.p1.mutable.ZorroBlueprintChoice
+    val mBlueprint = new edu.gemini.model.p1.mutable.ZorroBlueprint
+    choice.setZorro(mBlueprint)
+
+    mBlueprint.setId(getBlueprintId)
+    mBlueprint.setName(getName)
+    mBlueprint.setMode(mode)
+
+    new BlueprintPair(choice, mBlueprint)
+  }
+
+  override def getComplementaryInstrumentBlueprint = throw new RuntimeException("Switching sites has no meaning for Zorro blueprints.")
+
+  override def getResourcesByCategory = Map[String, java.util.Set[String]]("mode" -> Set[String](mode.value()).asJava).asJava
+
+  override def isMOS: Boolean = false
+}

--- a/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/zorro/ZorroBlueprint.scala
+++ b/phase1-data/src/main/java/edu/gemini/tac/persistence/phase1/blueprint/zorro/ZorroBlueprint.scala
@@ -39,6 +39,7 @@ class ZorroBlueprint(b: edu.gemini.model.p1.mutable.ZorroBlueprint) extends Blue
     mBlueprint.setId(getBlueprintId)
     mBlueprint.setName(getName)
     mBlueprint.setMode(mode)
+    mBlueprint.setVisitor(true)
 
     new BlueprintPair(choice, mBlueprint)
   }

--- a/phase1-data/src/main/resources/sessionFactory.xml
+++ b/phase1-data/src/main/resources/sessionFactory.xml
@@ -111,6 +111,8 @@
 
                 <value>edu.gemini.tac.persistence.phase1.blueprint.alopeke.AlopekeBlueprint</value>
 
+                <value>edu.gemini.tac.persistence.phase1.blueprint.zorro.ZorroBlueprint</value>
+
                 <value>edu.gemini.tac.persistence.phase1.blueprint.texes.TexesBlueprint</value>
 
                 <value>edu.gemini.tac.persistence.phase1.blueprint.trecs.TrecsBlueprintImaging</value>

--- a/queue-engine/qengine-p1-io/src/main/scala/edu/gemini/tac/qengine/p1/io/ObservationIo.scala
+++ b/queue-engine/qengine-p1-io/src/main/scala/edu/gemini/tac/qengine/p1/io/ObservationIo.scala
@@ -33,6 +33,7 @@ object ObservationIo {
       val imSite = p1Obs.blueprint.map {
         case d: im.DssiBlueprint       => d.site
         case a: im.AlopekeBlueprint    => a.site
+        case z: im.ZorroBlueprint      => z.site
         case t: im.TexesBlueprint      => t.site
         case p: im.PhoenixBlueprint    => p.site
         case v: im.VisitorBlueprint    => v.site


### PR DESCRIPTION
This is the code to add the instrument, Zorro (a permanent visitor instrument at GS replacing DSSI), to ITAC. This is mainly a call for comments: I still have to figure out how to do some testing with ITAC in order to verify that this works properly, although it is a straightforward modification of the code implemented to add ʻAlopeke to GN to replace the GN DSSI.