### PR TITLE
REL-3677 Remove empty observations before feeding them to the queue engine

### DIFF
--- a/queue-service/ps-conversion/src/main/scala/edu/gemini/tac/psconversion/P1ModelConverter.scala
+++ b/queue-service/ps-conversion/src/main/scala/edu/gemini/tac/psconversion/P1ModelConverter.scala
@@ -1,6 +1,7 @@
 package edu.gemini.tac.psconversion
 
 import edu.gemini.model.p1.immutable.{Proposal => P1Proposal}
+import edu.gemini.model.p1.{mutable => p1mutable}
 
 import edu.gemini.tac.persistence.{Proposal => PsProposal}
 
@@ -33,10 +34,15 @@ class P1ModelConverter(partners: List[Partner]) {
       HibernateToMutableConverter.toMutable(ps.getPhaseIProposal)
     }
 
+    def cleanProposal(m: p1mutable.Proposal): P1Proposal = {
+      val p1 = P1Proposal(m)
+      p1.copy(observations = p1.nonEmptyObservations)
+    }
+
     // Go back to the safe immutable model and extract the qengine proposal
     // information from that.
     mutable.flatMap { mut =>
-      io.read(P1Proposal(mut), when, idGen).disjunction.leftMap(l => BadData(l.list.toList.mkString("\n")))
+      io.read(cleanProposal(mut), when, idGen).disjunction.leftMap(l => BadData(l.list.toList.mkString("\n")))
     }
   }
 

--- a/queue-service/qservice-impl/src/main/scala/edu/gemini/tac/qservice/impl/QueueServiceImpl.scala
+++ b/queue-service/qservice-impl/src/main/scala/edu/gemini/tac/qservice/impl/QueueServiceImpl.scala
@@ -66,7 +66,7 @@ private class QueueServiceImpl(val queue: PsQueue, val comService: PsCommitteeSe
     pl  <- new ProposalLoader(ctx, par).load(ps.asScala.toList)
   } yield pl
 
-  val proposals = for {
+  val proposals: PsError \/ List[Proposal] = for {
     pr <- proposalResults
   } yield (List.empty[Proposal]/:pr) { (lst,r) =>
     r match {

--- a/queue-service/qservice-impl/src/main/scala/edu/gemini/tac/qservice/impl/load/ProposalLoader.scala
+++ b/queue-service/qservice-impl/src/main/scala/edu/gemini/tac/qservice/impl/load/ProposalLoader.scala
@@ -47,7 +47,10 @@ object ProposalLoader {
     (for {
       p1 <- nullSafePersistence("phase 1 proposal not set") { p.getPhaseIProposal }
       m  <- nullSafePersistence("could not convert to mutable proposal") { HibernateToMutableConverter.toMutable(p1) }
-    } yield im.Proposal(m)).leftMap(psErrorMessage(_).wrapNel).validation
+    } yield {
+      val p = im.Proposal(m)
+      p.copy(observations = p.nonEmptyObservations)
+    }).leftMap(psErrorMessage(_).wrapNel).validation
   }
 
   // A result of loading a single persistence proposal.  It pairs the original


### PR DESCRIPTION
REL-3920 Introduced a change on the PIT where we add an empty observation if none is defined for either band3 or band1/2. This change has downstream implications in ITAC where this empty observation is added at the moment proposals are ingested into the queue engine

This PR removes these extra observations letting the queue engine use all the valid proposals