### PR TITLE
REL-3678: ITAC NPE on band3 proposal check without band3 request

### DIFF
--- a/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/ProposalChecker.scala
+++ b/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/ProposalChecker.scala
@@ -21,6 +21,7 @@ object ProposalChecker extends api.ProposalChecker {
 
   val checkList = List[CheckFunction](
     Band3ConditionsCheck,
+    Band3RequestedTime,
     Band3MinimumTimeCheck,
     ClassicalTimeRequestCheck,
     ConditionsCheck,

--- a/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/checks/Band3RequestedTime.scala
+++ b/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/checks/Band3RequestedTime.scala
@@ -1,0 +1,29 @@
+package edu.gemini.tac.service.check.impl.checks
+
+import edu.gemini.tac.persistence.phase1.proposal.QueueProposal
+import edu.gemini.tac.persistence.{Proposal, ProposalIssueCategory}
+import edu.gemini.tac.service.check.impl.core.ProposalIssue._
+import edu.gemini.tac.service.check.impl.core.StatelessProposalCheckFunction
+import edu.gemini.tac.service.{check => api}
+
+object Band3RequestedTime extends StatelessProposalCheckFunction {
+  val name        = "Band3 requested time"
+  val description =
+    "Proposals with band 3 must have a requested time."
+
+  def missingRequestedTime(p: Proposal): api.ProposalIssue =
+    error(this, p, "Proposal with band3 observations did not request band 3 time", ProposalIssueCategory.TimeAllocation)
+
+  def apply(p: Proposal): Set[api.ProposalIssue] =
+    p.getPhaseIProposal match {
+      case q: QueueProposal if p.isBand3 && !p.isJointComponent =>
+        Option(q.getBand3Request) match {
+          case Some(_) => noIssues
+          case None => Set(missingRequestedTime(p))
+      }
+      case _ => noIssues
+    }
+
+}
+
+

--- a/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/checks/ClassicalTimeRequestCheck.scala
+++ b/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/checks/ClassicalTimeRequestCheck.scala
@@ -16,7 +16,7 @@ object ClassicalTimeRequestCheck extends StatelessProposalCheckFunction {
 
   val e = 0.000001
 
-  def notMultipleOfTenMessage(hrs: Double ) =
+  def notMultipleOfTenMessage(hrs: Double): String =
     "Classical proposal requested %.2f hours.".format(hrs)
   def notMultipleOfTen(p: Proposal, hrs: Double): Set[api.ProposalIssue] =
     singleWarning(p, notMultipleOfTenMessage(hrs), ProposalIssueCategory.TimeAllocation)
@@ -32,7 +32,7 @@ object ClassicalTimeRequestCheck extends StatelessProposalCheckFunction {
   def nonNightsIssues(p: Proposal, units: TimeUnit): Set[api.ProposalIssue] =
     p.totalRequestedTime map { t =>
       val hrs    = t.convertTo(TimeUnit.HR)
-      val intHrs = hrs.getValue.toBigInteger().intValue()
+      val intHrs = hrs.getValue.toBigInteger.intValue()
 
       if ((math.abs(hrs.getValue.doubleValue() - intHrs ) < e) && (intHrs % 10 == 0))
         noIssues
@@ -43,7 +43,7 @@ object ClassicalTimeRequestCheck extends StatelessProposalCheckFunction {
   def classicalIssues(p: Proposal): Set[api.ProposalIssue] =
     (for {
       units <- requestedTimeUnits(p)
-      if (units != TimeUnit.NIGHT)
+      if units != TimeUnit.NIGHT
     } yield nonNightsIssues(p, units)) getOrElse noIssues
 
   def apply(p: Proposal): Set[api.ProposalIssue] =

--- a/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/checks/RecommendedTimeCheck.scala
+++ b/phase1-services/src/main/scala/edu/gemini/tac/service/check/impl/checks/RecommendedTimeCheck.scala
@@ -25,7 +25,6 @@ object RecommendedTimeCheck extends StatelessProposalCheckFunction {
     QUEUE     -> queueMargin
   )
 
-
   def noRequestedTimeMessage = "PI requested time  not specified."
   def noRequestedTime(p: Proposal) = ProposalIssue.error(this, p, noRequestedTimeMessage, ProposalIssueCategory.TimeAllocation)
 
@@ -35,12 +34,12 @@ object RecommendedTimeCheck extends StatelessProposalCheckFunction {
   def negativeRecommendedTimeMessage = "Partner recommended time cannot be negative."
   def negativeRecommendedTime(p: Proposal) = ProposalIssue.error(this, p, negativeRecommendedTimeMessage, ProposalIssueCategory.TimeAllocation)
 
-  def lowRecommendedTimeMessage(rec: TimeAmount, req: TimeAmount) =
+  def lowRecommendedTimeMessage(rec: TimeAmount, req: TimeAmount): String =
     "Sum of partner recommended time (%.2f %s) less than total PI minimum request (%.2f %s).".format(rec.getValue, rec.getUnits.value(), req.getValue, req.getUnits.value())
   def lowRecommendedTime(p: Proposal, rec: TimeAmount, req: TimeAmount) =
     ProposalIssue.warning(this, p, lowRecommendedTimeMessage(rec, req), ProposalIssueCategory.TimeAllocation)
 
-  def tooMuchTimeMessage(rec: TimeAmount) =
+  def tooMuchTimeMessage(rec: TimeAmount): String =
     "Proposal is allocated a large amount of time: '%s' hours".format(rec.convertTo(TimeUnit.HR))
   def tooMuchTime(p: Proposal, rec: TimeAmount) =
     ProposalIssue.warning(this, p, tooMuchTimeMessage(rec), ProposalIssueCategory.TimeAllocation)
@@ -55,8 +54,8 @@ object RecommendedTimeCheck extends StatelessProposalCheckFunction {
     private def augmentedRecommended(p: Proposal): TimeAmount = {
       recommended + marginMap({
         p.getPhaseIProposal match {
-          case qp : QueueProposal => QUEUE
-          case cp : ClassicalProposal => CLASSICAL
+          case _: QueueProposal => QUEUE
+          case _: ClassicalProposal => CLASSICAL
           case _ => QUEUE
         }
       })


### PR DESCRIPTION
At ITAC check for band3 time can throw an NPE. The PIT should forbid this to happen but apparently it is possible to change the proposal in ITAC time to this situation

This PR removes the source of the NPE and adds another check for that specific situation