### PR TITLE
basic duplication check

### DIFF
--- a/modules/main/src/main/scala/operation/Duplicates.scala
+++ b/modules/main/src/main/scala/operation/Duplicates.scala
@@ -12,38 +12,34 @@ import itac.Operation
 import itac.util.TargetDuplicationChecker
 import cats.effect.Sync
 import cats.effect.Blocker
-import itac.ObservationDigest
-import edu.gemini.tac.qengine.p1.Observation
 import gsp.math.HourAngle
 import gsp.math.Angle
 import edu.gemini.tac.qengine.p1.Proposal
+import edu.gemini.tac.qengine.p1.Target
 
 object Duplicates {
 
   def apply[F[_]: Sync: Parallel](tolerance: Angle): Operation[F] =
     new Operation[F] {
 
-      def printObs(ref: String)(o: Observation): Unit = {
-        val id     = ObservationDigest.digest(o.p1Observation)
-        val ra     = HourAngle.HMS(Angle.hourAngle.get(Angle.fromDoubleDegrees(o.target.ra.mag))).format
-        val dec    = Angle.DMS(Angle.fromDoubleDegrees(o.target.dec.mag)).format
-        val coords = f"${o.conditions.cc}%-5s ${o.conditions.iq}%-5s ${o.conditions.sb}%-5s ${o.conditions.wv}%-5s "
-        val hrs    = o.time.toHours.value
-        println(f"$ref%-20s $id $hrs%5.1fh $coords $ra%16s $dec%16s ${o.target.name.orEmpty}")
+      def printTarget(ref: String)(target: Target): Unit = {
+        val ra     = HourAngle.HMS(Angle.hourAngle.get(Angle.fromDoubleDegrees(target.ra.mag))).format
+        val dec    = Angle.DMS(Angle.fromDoubleDegrees(target.dec.mag)).format
+        println(f"$ref%-20s $ra%16s $dec%16s ${target.name.orEmpty}")
       }
 
       def checkForDuplicates(proposals: List[Proposal]): F[Unit] = {
-        val tdc = new TargetDuplicationChecker(proposals, tolerance)
+        val tdc  = new TargetDuplicationChecker(proposals, tolerance)
+        val dups = tdc.allClusters
         Sync[F].delay {
             println()
             println(s"${Console.BOLD}Target Duplication Report${Console.RESET}")
-            println(s"Grouped targets differ by an angular distance ≤ ${Angle.fromStringDMS.reverseGet(tolerance)}.")
+            println(s"Target clusters with minimal spanning tree edges ≤ ${Angle.fromStringDMS.reverseGet(tolerance)}.")
             println()
-        } *> tdc.duplicates.traverse_{ ds =>
+        } *> dups.traverse_{ ds =>
           Sync[F].delay {
-            ds.foreach { case (p, nel) =>
-              val obs = (p.obsList ++ p.band3Observations).filter(o => nel.contains_(ObservationDigest.digest(o.p1Observation)))
-              obs.foreach(printObs(p.id.reference))
+            ds.foreach { case (p, nec) =>
+              nec.toList.foreach(printTarget(p))
             }
             println()
           }
@@ -52,7 +48,7 @@ object Duplicates {
 
       def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] = {
         for {
-          ps <- ws.proposals.map(_.sortBy(_.id))
+          ps <- ws.proposals
           _  <- checkForDuplicates(ps)
         } yield ExitCode.Success
       }

--- a/modules/main/src/main/scala/operation/Duplicates.scala
+++ b/modules/main/src/main/scala/operation/Duplicates.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package itac.operation
+
+import cats._
+import cats.effect.ExitCode
+import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
+import itac.Workspace
+import itac.Operation
+import itac.util.TargetDuplicationChecker
+import cats.effect.Sync
+import cats.effect.Blocker
+import itac.ObservationDigest
+import edu.gemini.tac.qengine.p1.Observation
+import gsp.math.HourAngle
+import gsp.math.Angle
+import edu.gemini.tac.qengine.p1.Proposal
+
+object Duplicates {
+
+  def apply[F[_]: Sync: Parallel](tolerance: Angle): Operation[F] =
+    new Operation[F] {
+
+      def printObs(ref: String)(o: Observation): Unit = {
+        val id     = ObservationDigest.digest(o.p1Observation)
+        val ra     = HourAngle.HMS(Angle.hourAngle.get(Angle.fromDoubleDegrees(o.target.ra.mag))).format
+        val dec    = Angle.DMS(Angle.fromDoubleDegrees(o.target.dec.mag)).format
+        val coords = f"${o.conditions.cc}%-5s ${o.conditions.iq}%-5s ${o.conditions.sb}%-5s ${o.conditions.wv}%-5s "
+        val hrs    = o.time.toHours.value
+        println(f"$ref%-20s $id $hrs%5.1fh $coords $ra%16s $dec%16s ${o.target.name.orEmpty}")
+      }
+
+      def checkForDuplicates(proposals: List[Proposal]): F[Unit] = {
+        val tdc = new TargetDuplicationChecker(proposals, tolerance)
+        Sync[F].delay {
+            println()
+            println(s"${Console.BOLD}Target Duplication Report${Console.RESET}")
+            println(s"Grouped targets differ by an angular distance ≤ ${Angle.fromStringDMS.reverseGet(tolerance)}.")
+            println()
+        } *> tdc.duplicates.traverse_{ ds =>
+          Sync[F].delay {
+            ds.foreach { case (p, nel) =>
+              val obs = (p.obsList ++ p.band3Observations).filter(o => nel.contains_(ObservationDigest.digest(o.p1Observation)))
+              obs.foreach(printObs(p.id.reference))
+            }
+            println()
+          }
+        }
+      }
+
+      def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] = {
+        for {
+          ps <- ws.proposals.map(_.sortBy(_.id))
+          _  <- checkForDuplicates(ps)
+        } yield ExitCode.Success
+      }
+
+  }
+
+}

--- a/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
+++ b/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
@@ -1,0 +1,87 @@
+package itac.util
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import edu.gemini.tac.qengine.p1.Observation
+import edu.gemini.tac.qengine.p1.Proposal
+import edu.gemini.tac.qengine.p1.Target
+import gsp.math.Angle
+import gsp.math.Coordinates
+import itac.ObservationDigest
+
+/**
+ *
+ * @param tolerance Allowed tolerance in angular separation between target coordinates (default is
+ * one arcsecond).
+ */
+class TargetDuplicationChecker(proposals: List[Proposal], val tolerance: Angle = Angle.arcseconds.reverseGet(10)) {
+
+  // Sanity check
+  assert(tolerance.toSignedDoubleDegrees >= 0.0, "Tolerance must be an angle within [0, 180)°")
+
+  /** Get the gsp math coordinates from an engine model target. */
+  def coordinates(target: Target): Coordinates =
+    Coordinates.unsafeFromRadians(target.ra.toRad.mag, target.dec.toRad.mag)
+
+  /** Are these the same coordinates within our tolerance? */
+  def same(c1: Coordinates, c2: Coordinates): Boolean =
+    (c1 angularDistance c2).toMicroarcseconds < tolerance.toMicroarcseconds
+
+  /** Are these the same target within our tolerance? */
+  def same(t1: Target, t2: Target): Boolean =
+    same(coordinates(t1), coordinates(t2))
+
+  /**
+   * Given a reference target and a list of proposals, return a list of pairs of proposals and the
+   * digests of their matching observations.
+   */
+  def duplicates(referenceTarget: Target): List[(Proposal, NonEmptyList[String])] =
+    proposals.flatMap { p =>
+
+      // Digests of all observations in `p` that are close to `referenceTarget`.
+      val duplicateDigests: List[String] =
+        (p.obsList ++ p.band3Observations).flatMap { o =>
+          if (same(referenceTarget, o.target)) List(ObservationDigest.digest(o.p1Observation))
+          else Nil
+        }
+
+      // Only yield a value if there are duplicates.
+      NonEmptyList
+        .fromList(duplicateDigests)
+        .foldMap(nel => List((p, nel)))
+
+    }
+
+  // As we check for duplicates we accumulate a set of observation digests that have already been
+  // found to identify duplicates, as well as references targets that have already been examined.
+  // We don't need to look at these again. The algorithm is O(n^2) and this optimization cuts the
+  // search space in half in the worst case, more when there are duplicates.
+  //
+  // The set of duplicates for a given target can be discarded if only one program mentioned (this
+  // means that the target appears more than once in the same program, which is fine).
+
+  def duplicates: List[List[(Proposal, NonEmptyList[String])]] = {
+
+    // All observations, minus those with dummy targets.
+    val observations: List[Observation] =
+      proposals
+        .flatMap(p => p.obsList ++ p.band3Observations)
+        .filter(o => o.target.ra.mag != 0.0 || o.target.dec.mag != 0.0)
+
+    // As we check for duplicates we accumulate a set of observation digests that have already been
+    // found to identify duplicates, as well as references targets that have already been examined.
+    // We don't need to look at these again. The algorithm is O(n^2) and this optimization cuts the
+    // search space in half in the worst case, more when there are duplicates.
+    val initialState = (Set.empty[String], List.empty[List[(Proposal, NonEmptyList[String])]])
+    observations.foldLeft(initialState) { case ((seen, accum), o) =>
+
+      // ignore seen for now
+
+      (seen, duplicates(o.target) :: accum)
+
+    } ._2.filter(_.length > 1).distinct
+
+  }
+
+
+}


### PR DESCRIPTION
This adds `itac duplicates [--tolerance dd:mm:ss.nnn]` which computes clusters of targets with a minimum spanning tree whose edges are ≤ `tolerance`. Probably not adequate but it's a start.