### PR TITLE
export prep, fix termination case for impoverished proposal collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ itac-web/bin/
 .idea
 .metals
 .bloop
+.vscode
 work
 work2
+hawaii

--- a/modules/engine/src/main/scala/api/queue/ProposalQueue.scala
+++ b/modules/engine/src/main/scala/api/queue/ProposalQueue.scala
@@ -143,7 +143,7 @@ trait ProposalQueue {
 
   def programId(p: Proposal): Option[ProgramId] =
     positionOf(p).map(_.programNumber).map { num =>
-      val str = s"${p.site.abbreviation}-${p.p1proposal.get.semester.display}-${p.mode.programId}-$num"
+      val str = s"${p.site.abbreviation}-${p.p1proposal.semester.display}-${p.mode.programId}-$num"
       ProgramId.parse(str) // sorry
     }
 

--- a/modules/engine/src/main/scala/api/queue/time/PartnerTime.scala
+++ b/modules/engine/src/main/scala/api/queue/time/PartnerTime.scala
@@ -25,6 +25,8 @@ class PartnerTime private(val partners: List[Partner], val map: Map[Partner, Tim
 
   def -(that: PartnerTime): PartnerTime = timeOp(_ - _, that)
 
+  def filter(f: Partner => Boolean): PartnerTime = new PartnerTime(partners, map.filterKeys(f))
+
   def +(that: PartnerTime): PartnerTime = timeOp(_ + _, that)
 
   def *(perc: Percent): PartnerTime = percOp(_ * _, perc)

--- a/modules/engine/src/main/scala/impl/block/BlockIterator.scala
+++ b/modules/engine/src/main/scala/impl/block/BlockIterator.scala
@@ -193,12 +193,18 @@ object BlockIterator {
    * in order to be able to generate time blocks for all the proposals.
    */
   def apply(allPartners: List[Partner], quantaMap: PartnerTime, seq: Seq[Partner], propLists: Map[Partner, List[Proposal]], activeList : Proposal=>List[Observation]): BlockIterator = {
+
+    // Filter `quantaMap` to retain entries only for relevant partners; i.e., those who have
+    // proposals. Failure to do this can lead to nontermination in `advancePartner`.
+    val relevant   = propLists.toList.collect { case (p, _ :: _) => p } .toSet
+    val quantaMapʹ = quantaMap.filter(relevant)
+
     val iterMap = genIterMap(allPartners, propLists, activeList)
 
-    init(quantaMap, iterMap, seq, validpartners(allPartners, quantaMap)) match {
+    init(quantaMapʹ, iterMap, seq, validpartners(allPartners, quantaMapʹ)) match {
       case (s, t) if s.isEmpty => new Empty(allPartners)
       case (partnerSeq, remainingTime) => {
-        new BlockIteratorImpl(allPartners, quantaMap, partnerSeq, remainingTime, iterMap)
+        new BlockIteratorImpl(allPartners, quantaMapʹ, partnerSeq, remainingTime, iterMap)
       }
     }
   }

--- a/modules/engine/src/main/scala/p1/Ntac.scala
+++ b/modules/engine/src/main/scala/p1/Ntac.scala
@@ -3,12 +3,28 @@ package edu.gemini.tac.qengine.p1
 import edu.gemini.tac.qengine.util.{Percent, CompoundOrdering, Time}
 import edu.gemini.tac.qengine.p1.Ntac.Rank
 import edu.gemini.tac.qengine.ctx.{Share, Partner}
+import edu.gemini.model.p1.immutable.{ Submission, NgoSubmission }
 
 
-case class Ntac(partner: Partner, reference: String, ranking: Rank, awardedTime: Time, poorWeather: Boolean = false, lead: Option[String] = None,  comment: Option[String] = None) extends Ordered[Ntac] {
+case class Ntac(partner: Partner,
+  reference: String,
+  ranking: Rank,
+  awardedTime: Time,
+  poorWeather: Boolean,
+  lead: Option[String] = None,
+  comment: Option[String] = None,
+  submission: Submission = null
+) extends Ordered[Ntac] {
   require(awardedTime.ms >= 0, "Awarded time must be non-negative, not " + awardedTime.ms)
 
   def compare(that: Ntac): Int = Ntac.MasterOrdering.compare(this, that)
+
+  def ngoSubmission: NgoSubmission =
+    submission match {
+      case s: NgoSubmission => s
+      case _ => sys.error(s"Not an NgoSubmission: $submission")
+    }
+
 }
 
 object Ntac {
@@ -61,12 +77,11 @@ object Ntac {
     (Time.ZeroHours/:ntacs)(_ + _.awardedTime)
 
   def apply(partner: Partner, reference: String, ranking: Double, awardedTime: Time, poorWeather : Boolean): Ntac =
-      new Ntac(partner, reference, Ntac.Rank(ranking), awardedTime, poorWeather, lead = None)
-
+      new Ntac(partner, reference, Ntac.Rank(ranking), awardedTime, poorWeather)
 
   def apply(partner: Partner, reference: String, ranking: Double, awardedTime: Time): Ntac =
-    new Ntac(partner, reference, Ntac.Rank(ranking), awardedTime, poorWeather = false, lead = None)
+    new Ntac(partner, reference, Ntac.Rank(ranking), awardedTime, false)
 
   def apply(partner: Partner, reference: String, ranking: Double, awardedTime: Time, lead: String): Ntac =
-    new Ntac(partner, reference, Ntac.Rank(ranking), awardedTime, poorWeather = false, Some(lead))
+    new Ntac(partner, reference, Ntac.Rank(ranking), awardedTime, false, Some(lead))
 }

--- a/modules/engine/src/main/scala/p1/Proposal.scala
+++ b/modules/engine/src/main/scala/p1/Proposal.scala
@@ -73,7 +73,7 @@ sealed trait Proposal {
   def isJointComponent: Boolean = false
   def piEmail: Option[String]
 
-  def p1proposal: Option[edu.gemini.model.p1.immutable.Proposal]
+  def p1proposal: edu.gemini.model.p1.immutable.Proposal
 
 }
 
@@ -92,7 +92,7 @@ case class CoreProposal(
   isPoorWeather: Boolean = false,
   piName: Option[String] = None,
   piEmail: Option[String] = None,
-  p1proposal: Option[edu.gemini.model.p1.immutable.Proposal] = None
+  p1proposal: edu.gemini.model.p1.immutable.Proposal = null // to avoid having to generate one for testcases that don't care
 ) extends Proposal {
   def core: CoreProposal = this
 }
@@ -111,7 +111,7 @@ sealed abstract class DelegatingProposal(coreProposal: Proposal) extends Proposa
   def isPoorWeather: Boolean               = coreProposal.isPoorWeather
   def piName: Option[String]               = coreProposal.piName
   def piEmail: Option[String]              = coreProposal.piEmail
-  def p1proposal: Option[edu.gemini.model.p1.immutable.Proposal] = coreProposal.p1proposal
+  def p1proposal: edu.gemini.model.p1.immutable.Proposal = coreProposal.p1proposal
 }
 
 /**

--- a/modules/engine/src/main/scala/p1/io/NtacIo.scala
+++ b/modules/engine/src/main/scala/p1/io/NtacIo.scala
@@ -42,8 +42,8 @@ object NtacIo {
         }
     }
 
-  private def mkNtac(lead: Option[String])(p: Partner)(response: Option[Response]): Option[Ntac] =
-    response.map { r => Ntac(p, r.ref, r.rank, r.awardedTime, r.poorWeather, lead) }
+  private def mkNtac(lead: Option[String], submission: im.Submission)(p: Partner)(response: Option[Response]): Option[Ntac] =
+    response.map { r => Ntac(p, r.ref, r.rank, r.awardedTime, r.poorWeather, lead, None, submission) }
 
   private val NoneAccepted = NONE_ACCEPTED.failureNel[NonEmptyList[Ntac]]
 
@@ -83,7 +83,7 @@ class NtacIo(partners: Map[String, Partner]) {
 
   private def ntac(sub: im.Submission, partnerId: String, lead: Option[String]): ValidationNel[String, Option[Ntac]] = {
     val partner = partners.get(partnerId).toSuccess(UNKNOWN_PARTNER_ID(partnerId).wrapNel)
-    response(sub, partnerId) <*> partner.map(mkNtac(lead))
+    response(sub, partnerId) <*> partner.map(mkNtac(lead, sub))
   }
 }
 

--- a/modules/engine/src/main/scala/p1/io/ProposalIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ProposalIo.scala
@@ -89,7 +89,7 @@ class ProposalIo(partners: Map[String, Partner]) {
             ntac.poorWeather,
             piName(p),
             piEmail(p),
-            Some(p)
+            p
           )
 
           // If there are more ntacs, it is a Joint, otherwise just this core.

--- a/modules/engine/src/test/scala/edu/gemini/tac/qengine/p1/io/NtacIoTest.scala
+++ b/modules/engine/src/test/scala/edu/gemini/tac/qengine/p1/io/NtacIoTest.scala
@@ -43,6 +43,12 @@ class NtacIoTest {
 
   val ntacIo = new NtacIo(TestPartners.AllMap)
 
+  // HACK HACK HACK
+  // Let's ignore the p1 node in Ntac (added long after this test was written) because it's not relevant.
+  def stripP1Node(n: Ntac): Ntac = n.copy(submission = null)
+  def assertEquals(a: Any, b: Any): Unit = Assert.assertEquals(a, b)
+  def assertEquals(n1: Ntac, n2: Ntac): Unit = Assert.assertEquals(stripP1Node(n1), stripP1Node(n2))
+  def assertEquals(ns1: IList[Ntac], ns2: IList[Ntac]): Unit = Assert.assertEquals(ns1.map(stripP1Node), ns2.map(stripP1Node))
 
   def fixtureNtac(p: ProposalFixture) = {
     Ntac(AU, p.submissionId, Ntac.Rank(some(p.partnerRanking)), Time.hours(1.0), poorWeather = false, some(p.pi.lastName))

--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -168,6 +168,12 @@ trait MainOpts { this: CommandIOApp =>
       header = "Generate a queue."
     )((siteConfig, rolloverReport).mapN((sc, rr) => Queue[IO](QueueEngine, sc, rr)))
 
+  lazy val export: Command[Operation[IO]] =
+    Command(
+      name   = "export",
+      header = "Export proposals."
+    )((siteConfig, rolloverReport).mapN((sc, rr) => Export[IO](QueueEngine, sc, rr)))
+
   lazy val gn: Opts[Site.GN.type] = Opts.flag(
     short = "n",
     long  = "north",
@@ -271,7 +277,8 @@ trait MainOpts { this: CommandIOApp =>
       rollover,
       queue,
       summarize,
-      duplicates
+      duplicates,
+      export
     ).sortBy(_.name).map(Opts.subcommand(_)).foldK
 
 }

--- a/modules/main/src/main/scala/operation/AbstractQueueOperation.scala
+++ b/modules/main/src/main/scala/operation/AbstractQueueOperation.scala
@@ -86,7 +86,7 @@ abstract class AbstractQueueOperation[F[_]](
   def addOrUpdateItacNode(p: Proposal, q: ProposalQueue): Proposal = {
 
     // P1Proposal, which should always be present
-    val p1 = p.p1proposal.getOrElse(sys.error(s"No p1 proposal associated with ${p.id.reference}"))
+    val p1 = p.p1proposal
 
     // Our decision, based on presence of a queue position.
     val decision: Either[ItacReject, ItacAccept] =
@@ -115,9 +115,9 @@ abstract class AbstractQueueOperation[F[_]](
 
     // New Proposal
     val pʹ = p match {
-      case cp: CoreProposal      => cp.copy(p1proposal = Some(p1ʹ))
-      case jp: JointProposal     => jp.copy(core = jp.core.copy(p1proposal = Some(p1ʹ)))
-      case pp: JointProposalPart => pp.copy(core = pp.core.copy(p1proposal = Some(p1ʹ)))
+      case cp: CoreProposal      => cp.copy(p1proposal = p1ʹ)
+      case jp: JointProposal     => jp.copy(core = jp.core.copy(p1proposal = p1ʹ))
+      case pp: JointProposalPart => pp.copy(core = pp.core.copy(p1proposal = p1ʹ))
     }
 
     // Done

--- a/modules/main/src/main/scala/operation/Email.scala
+++ b/modules/main/src/main/scala/operation/Email.scala
@@ -187,11 +187,10 @@ object Email {
         mut = mut // defeat bogus unused warning
 
         // bindings that are always present
-        mut += "semester" -> s.toString
+        mut += "semester"  -> s.toString
 
         p.piEmail     .foreach(v => mut += "piMail"       -> v)
         p.piName      .foreach(v => mut += "piName"       -> v)
-        p.p1proposal  .foreach(p => mut += "progTitle"    -> p.title)
 
         //     // proposals that made it that far must have an itac part, accepted ones must have an accept part
         //     Validate.notNull(proposal.getPhaseIProposal());
@@ -200,7 +199,7 @@ object Email {
         //     // get some of the important objects
         //     PhaseIProposal doc = proposal.getPhaseIProposal();
         //     Itac itac = proposal.getItac();
-        val itac = p.p1proposal.get.proposalClass.itac
+        val itac = p.p1proposal.proposalClass.itac
         //     Investigator pi = doc.getInvestigators().getPi();
         //     Submission partnerSubmission = doc.getPrimary();
 
@@ -312,14 +311,14 @@ object Email {
         //     // emails will be concatenated to a list separated by semi-colons
         //     this.piMail = pi.getEmail();
         //     this.piName = pi.getFirstName() + " " + pi.getLastName();
-        val pi = p.p1proposal.get.investigators.pi
+        val pi = p.p1proposal.investigators.pi
         mut += "piMail"       -> s"${pi.firstName} ${pi.lastName}"
         mut += "piName"       -> pi.email
 
         //     if (doc.getTitle() != null) {
         //         this.progTitle = doc.getTitle();
         //     }
-        p.p1proposal  .foreach(p => mut += "progTitle"    -> p.title)
+        mut += "progTitle"    -> p.p1proposal.title
 
         //     if (banding != null) {
         //         this.queueBand = banding.getBand().getDescription();

--- a/modules/main/src/main/scala/operation/Export.scala
+++ b/modules/main/src/main/scala/operation/Export.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package itac
+package operation
+
+import cats._
+import cats.effect._
+import cats.implicits._
+import edu.gemini.tac.qengine.api.QueueEngine
+import io.chrisdavenport.log4cats.Logger
+import java.nio.file.Path
+
+object Export {
+
+  /**
+    * @param siteConfig path to site-specific configuration file, which can be absolute or relative
+    *   (in which case it will be resolved relative to the workspace directory).
+    */
+  def apply[F[_]: Sync: Parallel](
+    qe:             QueueEngine,
+    siteConfig:     Path,
+    rolloverReport: Option[Path]
+  ): Operation[F] =
+    new AbstractQueueOperation[F](qe, siteConfig, rolloverReport) {
+
+      def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] =
+        computeQueue(ws).flatMap { case (_, qc) =>
+          Sync[F].delay {
+            println("export!")
+
+            val q = qc.queue
+
+            qc.queue.toList.foreach { p =>
+              val pid = q.programId(p).get
+              println(s"Exporting $pid -- ${p.id.reference}")
+
+
+
+            }
+
+
+
+            ExitCode.Success
+          }
+        }
+
+  }
+
+}
+
+

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -18,6 +18,7 @@ import java.nio.file.Path
 import _root_.edu.gemini.tac.qengine.log.RejectCategoryOverAllocation
 import edu.gemini.tac.qengine.log.RejectTarget
 import edu.gemini.tac.qengine.log.RejectConditions
+import edu.gemini.tac.qengine.ctx.Partner
 
 object Queue {
 
@@ -93,8 +94,10 @@ object Queue {
 
               println(separator)
 
+              def hasProposals(p: Partner): Boolean = ps.exists(_.ntac.partner == p)
+
               // Partners that appear in the queue
-              partners.filter(queueCalc.queue.queueTime(_).toHours.value > 0) foreach { p =>
+              partners.filter(p => queueCalc.queue.queueTime(p).toHours.value > 0 && hasProposals(p)) foreach { p =>
                 println(s"${Console.BOLD}Partner Details for $p ${Console.RESET}")
                 QueueBand.values.foreach { qb =>
                   val q = queueCalc.queue

--- a/modules/main/src/main/scala/operation/Summarize.scala
+++ b/modules/main/src/main/scala/operation/Summarize.scala
@@ -80,7 +80,7 @@ object Summarize {
 
           println()
           println(s"Reference: ${p.id.reference}")
-          println(s"Title:     ${p.p1proposal.foldMap(_.title)}")
+          println(s"Title:     ${p.p1proposal.title}")
           println(s"PI:        ${p.piName.orEmpty}")
           println(s"Partner:   ${p.ntac.partner.fullName}")
           println(f"Award:     ${p.time.toHours.value}%1.1f hours")

--- a/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
+++ b/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package itac.util
 
 import cats.implicits._


### PR DESCRIPTION
Two unrelated things here, sorry. Needed to work fast.

- Attempts to make `Proposal.p1proposal` exportable to OCS by merging the NTAC submission nodes from joint proposal parts.
- Fixes a nontermination issue in `BlockIterator` that can happen if a partner has time quanta but no proposals.
