### PR TITLE
reformat queue output per user feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,12 @@ target
 itac-web/bin/
 .idea
 .metals
+project/metals.sbt
 .bloop
 .vscode
+
+# rob's local work
+modules/main/src/main/scala/ws/
 work
 work2
 hawaii

--- a/modules/engine/src/main/scala/impl/QueueEngine.scala
+++ b/modules/engine/src/main/scala/impl/QueueEngine.scala
@@ -85,7 +85,7 @@ object QueueEngine extends edu.gemini.tac.qengine.api.QueueEngine {
 
     val raTablesANSI: String =
       report.flatten.map {
-        case RaRow(h, r, l)         => f"${Console.BOLD}RA: $h%-78s   $r%6.2f  $l%6.2f${Console.RESET}"
+        case RaRow(h, r, l)         => f"\n${Console.BOLD}RA: $h%-78s   $r%6.2f  $l%6.2f${Console.RESET}"
         case ConditionsRow(t, r, l) => f"Conditions: $t%-70s   $r%6.2f  $l%6.2f "
       } .mkString("\n")
 

--- a/modules/main/src/main/scala/package.scala
+++ b/modules/main/src/main/scala/package.scala
@@ -1,0 +1,12 @@
+import cats.Monoid
+import edu.gemini.tac.qengine.util.Time
+
+package object itac {
+
+  implicit val MonoidTime: Monoid[Time] =
+    new Monoid[Time] {
+      def combine(x: Time, y: Time): Time = x + y
+      def empty: Time = Time.Zero
+    }
+
+}

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1-190-ef7d8dba")


### PR DESCRIPTION
Per Marie's email:

- format proposals as rank / reference / pi / time / progid
- sort by rank
- move rejection report to the bottom
- add date/time header
