### PR TITLE
adjust award based on proportion of estimate per site

### DIFF
--- a/modules/engine/src/main/scala/p1/io/ProposalIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ProposalIo.scala
@@ -10,6 +10,9 @@ import edu.gemini.tac.qengine.p1._
 
 import scalaz._
 import Scalaz._
+import edu.gemini.spModel.core.Site
+import edu.gemini.tac.qengine.util.Percent
+import com.itextpdf.text.log.LoggerFactory
 
 /**
   * Immutable Phase1 proposal
@@ -66,21 +69,46 @@ class ProposalIo(partners: Map[String, Partner]) {
       // Discover which sites are used in the observations.
       val sites = obsGroups.map(_._1).list.toList.distinct
 
+      // Get the total estimated time at a given site.
+      def totalEstimatedTime(site: Site) =
+        obsGroups.list.collect {
+          case (`site`, _, os) => os.foldMap(_.time)
+        } .foldMap(identity)
+
+      // Get estimated time for each site, as well as their sum.
+      val tetGN = totalEstimatedTime(Site.GN)
+      val tetGS = totalEstimatedTime(Site.GS)
+      val tet   = tetGN + tetGS
+
       // Make a proposal per site represented in the observations.
       val (props, newGen) = sites.foldLeft((List.empty[Proposal], jointIdGen)) {
         case ((propList, gen), site) =>
+
           // Get the list of observations associated with the given band category (if any).
           def bandList(cat: QueueBand.Category): List[Observation] =
             ~obsGroups.list
               .find { case (s, b, _) => s == site && b == cat }
               .map(_._3.list.toList)
 
-          // Make the corresponding CoreProposal
+          // The first NTAC is the one we care about here (why?)
           val ntac = ntacs.head
+
+          // Figure out the proportion of estimated time we're using for the current site, and
+          // scale the total award by that amount. For proposals that are only at one site the
+          // proportion is 100% and the scaling is a no-op.
+          val tetThis = if (site == Site.GN) tetGN else tetGS
+          val proportion = tetThis.ms.toDouble / tet.ms.toDouble
+          val scaledAward = ntac.awardedTime * Percent(proportion * 100)
+          val ntacʹ = ntac.copy(awardedTime = scaledAward)
+
+          if (proportion != 1.0)
+            println(f"${ntac.reference}%-15s est for ${site.abbreviation} is ${tetThis.toHours.value}%5.1f h (${proportion * 100}%5.1f%% of total) ... scaled award is ${scaledAward.toHours.value}%5.1f of ${ntac.awardedTime.toHours.value}%5.1f")
+
+          // Make the corresponding CoreProposal
           val b12 = bandList(QueueBand.Category.B1_2)
           val b3 = bandList(QueueBand.Category.B3)
           val core = CoreProposal(
-            ntac,
+            ntacʹ,
             site,
             mode(p),
             too(p),

--- a/modules/engine/src/main/scala/p1/io/ProposalIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ProposalIo.scala
@@ -12,7 +12,6 @@ import scalaz._
 import Scalaz._
 import edu.gemini.spModel.core.Site
 import edu.gemini.tac.qengine.util.Percent
-import com.itextpdf.text.log.LoggerFactory
 
 /**
   * Immutable Phase1 proposal

--- a/modules/engine/src/main/scala/util/Time.scala
+++ b/modules/engine/src/main/scala/util/Time.scala
@@ -1,6 +1,7 @@
 package edu.gemini.tac.qengine.util
 
 import Time.Units
+import scalaz.Monoid
 
 object Time {
   sealed abstract class Units extends Ordered[Units] with Serializable {
@@ -72,6 +73,9 @@ object Time {
     def *(t: Time): Time = t * p
   }
   implicit val toPercentMultiplier = (p: Percent) => new PercentMultiplier(p)
+
+  implicit val MonoidTime: Monoid[Time] =
+    Monoid.instance(_ + _, Zero)
 }
 
 final class Time private (val ms: Long, val unit: Units) extends Ordered[Time] with Serializable {
@@ -124,4 +128,5 @@ final class Time private (val ms: Long, val unit: Units) extends Ordered[Time] w
 //  def /(amt: Double): Time = Time((ms.toDouble / unit.toMs(amt).toDouble).round, unit)
 
   def toXML = <Time unit="minutes">{ this.toMinutes.value }</Time>
+
 }

--- a/modules/main/src/main/scala/operation/Summarize.scala
+++ b/modules/main/src/main/scala/operation/Summarize.scala
@@ -79,7 +79,7 @@ object Summarize {
             p.band3Observations.map(BandedObservation("B3", _))
 
           println()
-          println(s"Reference: ${p.id.reference}")
+          println(s"Reference: ${p.id.reference} (${p.site.abbreviation})")
           println(s"Title:     ${p.p1proposal.title}")
           println(s"PI:        ${p.piName.orEmpty}")
           println(s"Partner:   ${p.ntac.partner.fullName}")


### PR DESCRIPTION
This adjusts the awarded time for proposals that are split across sites, such that the awarded time is split in proportion to the estimated time. For now we're logging any adjustments so users can see what's going on because I'm not 100% confident this is the right way to do it. But I think it is.