### PR TITLE
improve queue output

### DIFF
--- a/modules/engine/src/main/scala/p1/Ntac.scala
+++ b/modules/engine/src/main/scala/p1/Ntac.scala
@@ -13,7 +13,8 @@ case class Ntac(partner: Partner,
   poorWeather: Boolean,
   lead: Option[String] = None,
   comment: Option[String] = None,
-  submission: Submission = null
+  submission: Submission = null,
+  undividedTime: Option[Time] = None, // this will be set to the original time if the actual time is reduced due to a site split
 ) extends Ordered[Ntac] {
   require(awardedTime.ms >= 0, "Awarded time must be non-negative, not " + awardedTime.ms)
 

--- a/modules/engine/src/main/scala/p1/Proposal.scala
+++ b/modules/engine/src/main/scala/p1/Proposal.scala
@@ -53,6 +53,12 @@ sealed trait Proposal {
   def time: Time = ntac.awardedTime
 
   /**
+   * Returns the original awarded time for this proposal, which will be more than `awardedTime` if
+   * the original proposal was split in half due to the presence of observations at both sites.
+   */
+  def undividedTime: Time = ntac.undividedTime.getOrElse(time)
+
+  /**
    * Gets the time for the given observation relative to the total for all
    * observations in the proposal.
    */

--- a/modules/engine/src/main/scala/p1/io/ProposalIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ProposalIo.scala
@@ -98,7 +98,7 @@ class ProposalIo(partners: Map[String, Partner]) {
           val tetThis = if (site == Site.GN) tetGN else tetGS
           val proportion = tetThis.ms.toDouble / tet.ms.toDouble
           val scaledAward = ntac.awardedTime * Percent(proportion * 100)
-          val ntacʹ = ntac.copy(awardedTime = scaledAward)
+          val ntacʹ = ntac.copy(awardedTime = scaledAward, undividedTime = Some(ntac.awardedTime))
 
           if (proportion != 1.0)
             println(f"${ntac.reference}%-15s est for ${site.abbreviation} is ${tetThis.toHours.value}%5.1f h (${proportion * 100}%5.1f%% of total) ... scaled award is ${scaledAward.toHours.value}%5.1f of ${ntac.awardedTime.toHours.value}%5.1f")

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -71,7 +71,7 @@ object Queue {
                   case 4 => Colors.RED
                 })
                 q.bandedQueue.get(qb).orEmpty.sortBy(_.ntac.ranking.num.orEmpty).foreach { p =>
-                    println(f"- ${p.ntac.ranking.num.orEmpty}%5.1f ${p.id.reference}%-13s ${p.piName.orEmpty.take(20)}%-20s ${p.time.toHours.value}%5.1f h  ${q.programId(p).get}")
+                    println(f"- ${p.ntac.ranking.num.orEmpty}%5.1f ${p.id.reference}%-15s ${p.piName.orEmpty.take(20)}%-20s ${p.time.toHours.value}%5.1f h  ${q.programId(p).get}")
                 }
                 println(Colors.RESET)
               }
@@ -93,13 +93,24 @@ object Queue {
                   }
                   val included = q.bandedQueue.get(qb).orEmpty.filter(_.ntac.partner == p)
                   included.sortBy(_.ntac.ranking.num.orEmpty).foreach { p =>
-                    println(f"$color- ${p.ntac.ranking.num.orEmpty}%5.1f ${p.id.reference}%-13s ${p.piName.orEmpty.take(20)}%-20s ${p.time.toHours.value}%5.1f h  ${q.programId(p).get}${Colors.RESET}")
+                    println(f"$color- ${p.ntac.ranking.num.orEmpty}%5.1f ${p.id.reference}%-15s ${p.piName.orEmpty.take(20)}%-20s ${p.time.toHours.value}%5.1f h  ${q.programId(p).get}${Colors.RESET}")
                   }
                   if (qb.number < 4) {
-                    val used = q.usedTime(qb, p).toHours.value
+                    val used  = q.usedTime(qb, p).toHours.value
                     val avail = q.queueTime(qb, p).toHours.value
                     val pct   = if (avail == 0) 0.0 else (used / avail) * 100
-                    println(f"                                 B${qb.number} Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%%)\n")
+                    println(f"                                 B${qb.number} Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%%)")
+
+                    // After the Band2 total print an extra B1+B2 total.
+                    if (qb == QueueBand.QBand2) {
+                      val used  = (q.usedTime(QueueBand.QBand1, p) + q.usedTime(QueueBand.QBand2, p)).toHours.value
+                      val avail = (q.queueTime(QueueBand.QBand1, p) + q.queueTime(QueueBand.QBand2, p)).toHours.value
+                      val pct   = if (avail == 0) 0.0 else (used / avail) * 100
+                      println(f"                              B1+B2 Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%%)")
+                    }
+
+                    println()
+
                   } else {
                     val used = q.usedTime(qb, p).toHours.value
                     println(f"                                 B${qb.number} Total: $used%5.1f h\n")

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -2,9 +2,11 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package itac
-
 package operation
 
+import edu.gemini.spModel.core.Site.GN
+import edu.gemini.spModel.core.Site.GS
+import edu.gemini.tac.qengine.p1.Proposal
 import itac.util.Colors
 import cats._
 import cats.effect._
@@ -141,6 +143,27 @@ object Queue {
                 }
                 println()
               }
+
+              // Find proposals with divided time.
+              val dividedProposals: List[Proposal] =
+                queueCalc.queue.toList.filter(p => p.time != p.undividedTime)
+
+              if (dividedProposals.nonEmpty) {
+                println(separator)
+                println(s"${Colors.BOLD}Time Computations for Proposals at Both Sites${Colors.RESET}\n")
+                println(s"${Colors.BOLD}  Reference        Award     GN     GS${Colors.RESET}")
+                                      //- CA-2020B-013     3.8 h    1.8    1.8
+                dividedProposals.foreach { p =>
+                  val t  = p.undividedTime.toHours.value
+                  val tʹ = p.time.toHours.value
+                  val (gn, gs) = queueCalc.context.site match {
+                    case GN => (tʹ, t - tʹ)
+                    case GS => (t - tʹ, tʹ)
+                  }
+                  println(f"- ${p.id.reference}%-13s  $t%5.1f h  $gn%5.1f  $gs%5.1f")
+                }
+              }
+
 
               ExitCode.Success
 


### PR DESCRIPTION
This adds a B1+B2 summary line for each partner, to make the overfill computation more apparent. It also adds a summary at the end of the queue explaining how time has been divided when proposals are split across sites.