### PR TITLE
loosen restrictions on obsids for rollovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ project/metals.sbt
 .vscode
 
 # rob's local work
-modules/main/src/main/scala/ws/
 work
 work2
 hawaii
+*.worksheet.sc

--- a/modules/engine/src/main/scala/p2/rollover/RolloverReport.scala
+++ b/modules/engine/src/main/scala/p2/rollover/RolloverReport.scala
@@ -60,7 +60,7 @@ object RolloverReport {
       val site = Site.parse(rollover \@ "site")
       val sem  = Semester.parse(rollover \@ "semester")
       val ins  = Instant.ofEpochMilli((rollover \@ "timestamp").toLong)
-      val ros  = (rollover \ "obs").toList.traverseU { RolloverObservation.fromXml(_, partners) }
+      val ros  = (rollover \ "obs").toList.traverseU(RolloverObservation.fromXml)
       ros match {
         case Right(ros) => RolloverReport(site, sem, ins, ros)
         case Left(e)    => sys.error(e)

--- a/modules/engine/src/test/scala/edu/gemini/tac/qengine/queue/time/RolloverTimeTest.scala
+++ b/modules/engine/src/test/scala/edu/gemini/tac/qengine/queue/time/RolloverTimeTest.scala
@@ -20,13 +20,12 @@ class RolloverTimeTest extends PartnerTimeCalcTestBase {
     assertZero(partnersExceptCL, rollover(Site.GN, rop, partners))
   }
 
-  val partner = CA
-  val obsId   = ObservationId.parse("GN-2011A-Q-1-2").get
+  val obsId   = "GN-2011A-Q-1-2"
   val target  = Target(15.0, 2.0)
   val conds   = ObservingConditions.AnyConditions
   val time    = Time.hours(100.0)
 
-  val ro      = RolloverObservation(partner, obsId, target, conds, time)
+  val ro      = RolloverObservation(obsId, target, conds, time)
 
   private def assert100Even(rop: RolloverReport): Unit = {
     val pt = rollover(Site.GN, rop, partners)
@@ -41,13 +40,12 @@ class RolloverTimeTest extends PartnerTimeCalcTestBase {
   }
 
   @Test def tstFilterSouth(): Unit = {
-    val partner = BR
-    val obsId   = ObservationId.parse("GS-2011A-Q-3-4").get
+    val obsId   = "GS-2011A-Q-3-4"
     val target  = Target(30.0, 3.0)
     val conds   = ObservingConditions.AnyConditions
     val time    = Time.hours(6.0)
 
-    val roSouth = RolloverObservation(partner, obsId, target, conds, time)
+    val roSouth = RolloverObservation(obsId, target, conds, time)
 
     val rop     = RolloverReport.empty.copy(obsList = List(ro, roSouth))
     assert100Even(rop)

--- a/modules/main/src/main/scala/Workspace.scala
+++ b/modules/main/src/main/scala/Workspace.scala
@@ -207,7 +207,7 @@ object Workspace {
         }
 
         def readRolloverReport(path: Path): F[RolloverReport] =
-          commonConfig.flatMap(cc => readData(path)(decoderRolloverReport(cc.engine.partners)))
+          readData(path)(decoderRolloverReport)
 
         def mkdirs(path: Path): F[Path] = {
           val p = dir.resolve(path)

--- a/modules/main/src/main/scala/codec/RolloverObservation.scala
+++ b/modules/main/src/main/scala/codec/RolloverObservation.scala
@@ -52,7 +52,7 @@ trait RolloverObservationCodec {
           RolloverObservation(oidʹ, Target(raʹ.toDoubleDegrees, decʹ.toDoubleDegrees), ObservingConditions(ccʹ, iqʹ, sbʹ, wvʹ), minsʹ)
         } .toEither.leftMap(_.getMessage)
 
-      case arr => Left(s"Expected ten columns, found ${arr.length}: $s")
+      case _ => Left(s"Invalid rollover file format. Please re-fetch via `itac -f rollover -s` or `-n`")
     }
 
 }

--- a/modules/main/src/main/scala/codec/RolloverReport.scala
+++ b/modules/main/src/main/scala/codec/RolloverReport.scala
@@ -3,8 +3,6 @@
 
 package itac.codec
 
-import edu.gemini.tac.qengine.ctx.Partner
-import edu.gemini.tac.qengine.p2.rollover.RolloverObservation
 import edu.gemini.tac.qengine.p2.rollover.RolloverReport
 import io.circe.Decoder
 import io.circe.Encoder
@@ -16,12 +14,7 @@ trait RolloverReportCodec {
   import rolloverobservatiom._
 
   implicit val encoderRolloverReport: Encoder[RolloverReport] = deriveEncoder
-
-  def decoderRolloverReport(partners: List[Partner]): Decoder[RolloverReport] = {
-    implicit val dro: Decoder[RolloverObservation] = decoderRolloverObservation(partners)
-    (dro, ())._2 // defeat the unused checker, which thinks `dro` is unused
-    deriveDecoder
-  }
+  implicit val decoderRolloverReport: Decoder[RolloverReport] = deriveDecoder
 
 }
 

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -151,8 +151,8 @@ object Queue {
               if (dividedProposals.nonEmpty) {
                 println(separator)
                 println(s"${Colors.BOLD}Time Computations for Proposals at Both Sites${Colors.RESET}\n")
-                println(s"${Colors.BOLD}  Reference        Award     GN     GS${Colors.RESET}")
-                                      //- CA-2020B-013     3.8 h    1.8    1.8
+                println(s"${Colors.BOLD}  Reference      PI                      Award     GN     GS${Colors.RESET}")
+                                      //- CA-2020B-013   Drout                   3.8 h    2.0    1.8
                 dividedProposals.foreach { p =>
                   val t  = p.undividedTime.toHours.value
                   val tʹ = p.time.toHours.value
@@ -160,7 +160,7 @@ object Queue {
                     case GN => (tʹ, t - tʹ)
                     case GS => (t - tʹ, tʹ)
                   }
-                  println(f"- ${p.id.reference}%-13s  $t%5.1f h  $gn%5.1f  $gs%5.1f")
+                  println(f"- ${p.id.reference}%-13s  ${p.piName.orEmpty.take(20)}%-20s  $t%5.1f h  $gn%5.1f  $gs%5.1f")
                 }
               }
 


### PR DESCRIPTION
New this semester we need to support DD rollovers, which have Gemini Staff as the partner, neither of which are cromulent values as far as ITAC is concerned. But it turns out neither the mode nor partner matter so I'm ignoring the partner, keeping the obsid as a String, and parsing out the site (which is the only value the engine actually cares about) on demand.

Users will need to re-fetch their rollover files because the partner column has disappeared.