### PR TITLE
fix two band3 issues

### DIFF
--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -26,6 +26,11 @@ import gsp.math.Angle
 import cats.instances.short
 import com.monovore.decline.Argument
 
+// object Stub {
+//   def main(args: Array[String]): Unit =
+//     Main.main(Array("-d", "hawaii", "summarize", "CL-2020B-014"))
+// }
+
 object Main extends CommandIOApp(
   name    = "itac",
   header  =

--- a/modules/main/src/main/scala/operation/Summarize.scala
+++ b/modules/main/src/main/scala/operation/Summarize.scala
@@ -17,6 +17,8 @@ import gsp.math.HourAngle
 import cats.Order
 import edu.gemini.tac.qengine.p1.Observation
 import cats.data.NonEmptyList
+import edu.gemini.tac.qengine.p1.JointProposal
+import edu.gemini.tac.qengine.ctx.Partner
 
 object Summarize {
 
@@ -78,11 +80,19 @@ object Summarize {
             p.obsList.map(BandedObservation("B1/2", _)) ++
             p.band3Observations.map(BandedObservation("B3", _))
 
+          // println(s"===> ${p.getClass}")
+
+          val partners: List[Partner] =
+            p match {
+              case JointProposal(_, _, ntacs) => ntacs.map(_.partner)
+              case p => List(p.ntac.partner)
+            }
+
           println()
-          println(s"Reference: ${p.id.reference} (${p.site.abbreviation})")
+          println(s"Reference: ${p.id.reference} (${p.site.abbreviation}, ${p.mode})")
           println(s"Title:     ${p.p1proposal.title}")
           println(s"PI:        ${p.piName.orEmpty}")
-          println(s"Partner:   ${p.ntac.partner.fullName}")
+          println(s"Partner:   ${partners.map(_.fullName).mkString(", ")}")
           println(f"Award:     ${p.time.toHours.value}%1.1f hours")
           println(f"Rank:      ${p.ntac.ranking.num.orEmpty}%1.1f")
           println(f"ToO:       ${p.too}")


### PR DESCRIPTION
This fixes two issues that were causing problems.

- The band1/2 queue sometimes overfills so far that the last proposal should technically spill over into band3, and that was happening but it's nonsensical because it's using the band1/2 observations. As a bonus these observations were getting clobbered by the band3 queue calculated in the next step. So I fixed that code to allow the engine to overfill band 2 as much as it wants, and we'll treat that as an orthogonal issue if it comes up.
- The band3 filter was adding messages to the log but the log wasn't being carried forward so all the `RejectBand3` log messages were getting lost. This is also fixed.

I left some debugging code in place as comments. Will circle back for those.