### PR TITLE
fix time-splitting when times are dedicated to one site or the other

### DIFF
--- a/modules/engine/src/main/scala/log/RejectNoTime.scala
+++ b/modules/engine/src/main/scala/log/RejectNoTime.scala
@@ -8,11 +8,11 @@ import xml.Elem
  */
 object RejectNoTime {
   val name        = "No Time Award"
-  val description = "NTAC did not award time to the proposal."
+  def description(p: Proposal) = s"No awarded time, or time is not usable at ${p.site}."
 }
 final case class RejectNoTime(prop: Proposal) extends RejectMessage {
   def reason: String = RejectNoTime.name
-  def detail: String = RejectNoTime.description
+  def detail: String = RejectNoTime.description(prop)
 
   override def subToXML : Elem = <NoTimeAward><Proposal id= { prop.id.toString }/></NoTimeAward>
 

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -161,7 +161,7 @@ object Queue {
               if (dividedProposals.nonEmpty) {
                 println(separator)
                 println(s"${Colors.BOLD}Time Computations for Proposals at Both Sites${Colors.RESET}\n")
-                println(s"${Colors.BOLD}  Reference        PI                      Award     GN     GS${Colors.RESET}")
+                println(s"${Colors.BOLD}  Reference         PI                      Award     GN     GS${Colors.RESET}")
                                       //- CA-2020B-013     Drout                   3.8 h    2.0    1.8
                 dividedProposals.foreach { p =>
                   val t  = p.undividedTime.toHours.value
@@ -170,7 +170,7 @@ object Queue {
                     case GN => (tʹ, t - tʹ)
                     case GS => (t - tʹ, tʹ)
                   }
-                  println(f"- ${p.id.reference}%-15s  ${p.piName.orEmpty.take(20)}%-20s  $t%5.1f h  $gn%5.1f  $gs%5.1f")
+                  println(f"- ${p.id.reference}%-16s  ${p.piName.orEmpty.take(20)}%-20s  $t%5.1f h  $gn%5.1f  $gs%5.1f")
                 }
               }
 

--- a/modules/main/src/main/scala/util/Colors.scala
+++ b/modules/main/src/main/scala/util/Colors.scala
@@ -8,7 +8,9 @@ import scala.io.AnsiColor
 /** Like `AnsiColor` but sets colors to "" if there's no console attached. */
 object Colors {
 
-  private lazy val isDetached = System.console == null
+  private lazy val isDetached = {
+    (!sys.props.contains("force-color")) && (System.console == null)
+  }
 
   private def color(s: String): String =
     if (isDetached) "" else s


### PR DESCRIPTION
Some proposals have observations at both sites, so we need to figure out how much awarded time goes to each site. Most partner time can be divided proportionally, but some partner time can be used only at one site or the other. That last bit is what this PR fixes, along with some wording improvements in associated messages.