### PR TITLE
Enable Editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ project/metals.sbt
 work
 work2
 hawaii
+2020B
 *.worksheet.sc

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ITAC is a command-line application that reads proposal XML files along with some
 Keep in mind the following big ideas:
 
 - All the input files are just normal text files. You can rename them, make backups, store them in source control, manage them however you like.
-- All proposal "edits" are specified as part of configuration and occur as proposals are loaded from disk. *The XML files are never touched.* This means you undo or change edits simply by updating the `edits.yaml` file (see below).
+- All proposal "edits" are specified as part of configuration and occur as proposals are loaded from disk. *The XML files are never touched.* This means you undo or change edits simply by updating the contents of the `edits/` folder.
 - The input files completely specify the Queue. If you want to have several queues that you can compare, you can have several sets of input files.
 
 Now let's examine these steps in more detail.
@@ -81,6 +81,7 @@ $ cd itac-example
 $ itac init 2020B
 [INFO ] Creating folder: email_templates
 [INFO ] Creating folder: proposals
+[INFO ] Creating folder: edits
 [INFO ] Writing: ./email_templates/ngo_classical.vm
 [INFO ] Writing: ./email_templates/ngo_exchange.vm
 [INFO ] Writing: ./email_templates/ngo_joint_classical.vm
@@ -92,10 +93,8 @@ $ itac init 2020B
 [INFO ] Writing: ./email_templates/pi_successful.vm
 [INFO ] Writing: ./email_templates/unsuccessful.vm
 [INFO ] Writing: ./common.yaml
-[INFO ] Writing: ./edits.yaml
 [INFO ] Writing: ./gn-queue.yaml
 [INFO ] Writing: ./gs-queue.yaml
-[INFO ] Fetching current rollover report from Gemini North...
 [INFO ] Got rollover information for 2020A
 [INFO ] Writing: ./gn-rollovers.yaml
 [INFO ] Fetching current rollover report from Gemini South...
@@ -110,7 +109,6 @@ $ itac init 2020B
 $ tree
 .
 ├── common.yaml
-├── edits.yaml
 ├── email_templates
 │   ├── ngo_classical.vm
 │   ├── ngo_exchange.vm
@@ -130,11 +128,11 @@ $ tree
 ```
 
 - `common.yaml` contains configuration that applies to all queues and is unlikely to change much. You will need to edit this file to specify shutdown times and partner contact emails. The rest is probably ok.
-- `edits.yaml` contains edits to proposals that you will make in the process of constructing your queue. We will revisit this later.
 - `email_templates/` contains the default email templates which are used to generate emails that are sent to partners and PIs. You can change these if you wish (and if you do, let us know so we can change the defaults) but they're probably ok.
 - `gn-queue.yaml` and `gs-queue.yaml` specify site-specific queue configurations. The most important part here is `hours` which specifies per-partner hours in bands 1, 2, and 3. Remaining configuration is probably ok.
 - `gn-rollovers.yaml` and `gn-rollovers.yaml` contain rollover reports fetched from the ODBs at GN and GS. You may wish to adjust the times here. To re-fetch a rollover report you can say `itac --force rollover --south` (or `--north`). Note that you must have an internal or VPN connection to do this.
 - `proposals/` is where your proposal XML files (from Jared's system) need to go.
+- `edits/` is where you define edits that are applied to the XML files as they are read.
 
 ### Get Help
 
@@ -172,8 +170,16 @@ itac queue --south
 
 ### Edit Proposals
 
-TBD
+`itac` allows you to define edits that are applied to proposals as the XML files are read. Here is the workflow.
 
-### Finalize a Queue
+- Use `itac summarize <ref>` to look at the proposal you wish to edit.
+- Use `itac summarize --edit <ref>` to write a copy of the summary into the `edits/` folder, with the name `<ref>.yaml`.
+- Edit the file in the `edits/` folder, making changes as instructed in the comment at the top of the file.
+- Changes will be applied each time the proposal is loaded from disk. The original XML file is never touched. You can verify changes by running `itac summarize <ref>` again.
+- To undo your edits, delete the edit file.
 
-TBD
+Limitations:
+
+- It is not possible to update ToO or nonsidereal targets using `itac`. Such edits will be ignored.
+- It is not possible to **add** observations. This must be done in the PIT.
+

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ $ itac init 2020B
 [INFO ] Writing: ./gn-queue.yaml
 [INFO ] Writing: ./gs-queue.yaml
 [INFO ] Got rollover information for 2020A
+[INFO ] Fetching current rollover report from Gemini North...
 [INFO ] Writing: ./gn-rollovers.yaml
 [INFO ] Fetching current rollover report from Gemini South...
 [INFO ] Got rollover information for 2020A

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ $ itac init 2020B
 [INFO ] Writing: ./common.yaml
 [INFO ] Writing: ./gn-queue.yaml
 [INFO ] Writing: ./gs-queue.yaml
-[INFO ] Got rollover information for 2020A
 [INFO ] Fetching current rollover report from Gemini North...
+[INFO ] Got rollover information for 2020A
 [INFO ] Writing: ./gn-rollovers.yaml
 [INFO ] Fetching current rollover report from Gemini South...
 [INFO ] Got rollover information for 2020A

--- a/modules/main/src/main/scala/Editor.scala
+++ b/modules/main/src/main/scala/Editor.scala
@@ -3,45 +3,70 @@
 
 package itac
 
-import cats._
+import cats.effect.Sync
 import cats.implicits._
-import edu.gemini.model.p1.immutable.Proposal
+import edu.gemini.model.p1.mutable.Proposal
+import edu.gemini.model.p1.{ immutable => im }
 import io.chrisdavenport.log4cats.Logger
-import edu.gemini.model.p1.immutable.GeminiNormalProposalClass
 import java.io.File
-import edu.gemini.model.p1.immutable.ExchangeProposalClass
-import itac.config.Edit
-import edu.gemini.model.p1.immutable.LargeProgramClass
 
 /** Proposal editing. This applies edits that are supplied as part of the configuration. */
-class Editor[F[_]: Applicative](edits: Map[String, Edit], log: Logger[F]) {
+class Editor[F[_]: Sync](edits: Map[String, SummaryEdit], log: Logger[F]) {
   import EditorOps._
 
-  def applyEdits(file: File, p: Proposal): F[Proposal] =
+  def applyEdits(file: File, p: Proposal): F[Unit] =
     edits.get(p.id) match {
-      case Some(f) => log.debug(s"There are edits for ${p.id}/${file.getName} -- $f").as(f(p))
-      case None    => log.trace(s"No edits for ${p.id}/${file.getName}").as(p)
+      case Some(e) =>
+
+        log.warn(s"There are edits for ${p.id}/${file.getName}") *>
+        Sync[F].delay {
+
+          // Show the before
+          // import javax.xml.bind.JAXBContext
+          // import javax.xml.bind.Marshaller
+          // val context: JAXBContext = {
+          //   val factory        = new edu.gemini.model.p1.mutable.ObjectFactory
+          //   JAXBContext.newInstance(factory.createProposal().getClass()) //contextPackage, getClass.getClassLoader)
+          // }
+          // val m = context.createMarshaller()
+          // m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+          // m.marshal(p, System.out)
+
+          e.update(p)
+
+          // And the after
+          // println(s"\n\napplied edits to ${p.id}\n\n")
+          // m.marshal(p, System.out)
+
+        }
+
+      case None    => log.warn(s"No edits for ${p.id}/${file.getName}")
+
     }
 
 }
 
 object EditorOps {
 
-  implicit class ProposalOps(self: Proposal) {
+  implicit class MutableProposalOps(self: Proposal) {
+    def id = im.Proposal(self).id
+  }
+
+  implicit class ProposalOps(self: im.Proposal) {
 
     def id: String =
       self.proposalClass match {
 
-        case pc: GeminiNormalProposalClass =>
+        case pc: im.GeminiNormalProposalClass =>
           (pc.subs match {
             case Left(ss)  => ss.flatMap(_.response.map(_.receipt.id)).headOption
             case Right(s)  => s.response.map(_.receipt.id)
           }).getOrElse(sys.error(s"Can't get id from ${pc.subs}"))
 
-        case pc: ExchangeProposalClass =>
+        case pc: im.ExchangeProposalClass =>
           pc.subs.flatMap(_.response.map(_.receipt.id)).headOption.getOrElse(sys.error(s"Can't get id from ${pc.subs}"))
 
-        case lp: LargeProgramClass =>
+        case lp: im.LargeProgramClass =>
           lp.sub.response.map(_.receipt.id).headOption.getOrElse(sys.error(s"Can't get id from ${lp.sub}"))
 
         case pc => sys.error(s"Unsupported proposal class: $pc")

--- a/modules/main/src/main/scala/Editor.scala
+++ b/modules/main/src/main/scala/Editor.scala
@@ -40,7 +40,7 @@ class Editor[F[_]: Sync](edits: Map[String, SummaryEdit], log: Logger[F]) {
 
         }
 
-      case None    => log.warn(s"No edits for ${p.id}/${file.getName}")
+      case None    => log.trace(s"No edits for ${p.id}/${file.getName}")
 
     }
 

--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -279,11 +279,18 @@ trait MainOpts { this: CommandIOApp =>
       help  = s"Fields to sort by, comma-delimited. One or more of ${Summarize.Field.all.map(_.name).mkString(",")}. Default is band,ra"
     ) .withDefault(NonEmptyList.of(Summarize.Field.band, Summarize.Field.ra))
 
+  lazy val edit: Opts[Boolean] =
+    Opts.flag(
+      long  = "edit",
+      short = "e",
+      help  = "Write the summary to the edits/ folder."
+    ).orFalse
+
   lazy val summarize: Command[Operation[IO]] =
     Command(
       name   = "summarize",
       header = "Summarize a proposal."
-    )((Opts.argument[String]("reference"), summarizeFields).mapN(Summarize(_, _)))
+    )((Opts.argument[String]("reference"), summarizeFields, edit).mapN(Summarize(_, _, _)))
 
   lazy val duplicates: Command[Operation[IO]] =
     Command(

--- a/modules/main/src/main/scala/ObservationDigest.scala
+++ b/modules/main/src/main/scala/ObservationDigest.scala
@@ -6,6 +6,7 @@ package itac
 import cats.Hash
 import cats.implicits._
 import edu.gemini.model.p1.immutable._
+import edu.gemini.model.p1.{ mutable => M }
 import edu.gemini.spModel.core.Coordinates
 import edu.gemini.spModel.core.Magnitude
 import edu.gemini.spModel.core.MagnitudeBand
@@ -133,5 +134,9 @@ object ObservationDigest {
   /** A zero-padded 8-character hash digest of the given observation. */
   def digest(o: Observation): String =
     ("00000000" + o.hash.toHexString).takeRight(8)
+
+  def digest(o: M.Observation): String =
+    digest(Observation(o))
+
 
 }

--- a/modules/main/src/main/scala/Summary.scala
+++ b/modules/main/src/main/scala/Summary.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package itac
 
 import cats.implicits._

--- a/modules/main/src/main/scala/Summary.scala
+++ b/modules/main/src/main/scala/Summary.scala
@@ -1,0 +1,86 @@
+package itac
+
+import cats.implicits._
+import edu.gemini.tac.qengine.p1.Proposal
+import itac.util.OneOrTwo
+import edu.gemini.tac.qengine.p1.Observation
+import gsp.math.HourAngle
+import gsp.math.Angle
+import gsp.math.Declination
+
+case class Summary(slices: OneOrTwo[Proposal]) {
+  import Summary.{ BandedObservation, Slice }
+
+  val siteSummaries: OneOrTwo[Slice] =
+    slices.map(Slice(_))
+
+  // As a sanity check let's glance at the proposals. There are many other things we assumed to be
+  // equal but if this checks out there would have to be something very wrong elswehere for the
+  // slices to not correspond.
+  slices.fold(_ => (), (a, b) => {
+    require(a.site       != b.site,       "sites must differ")
+    require(a.p1proposal == b.p1proposal, "underlying p1 proposals must be equal")
+  })
+
+  val reference = slices.fst.ntac.reference
+  val mode      = slices.fst.mode
+  val title     = slices.fst.p1proposal.title
+  val pi        = slices.fst.piName.orEmpty
+  val partner   = slices.fst.ntac.partner
+  val award     = slices.fst.ntac.awardedTime
+  val rank      = slices.fst.ntac.ranking.num.orEmpty
+  val too       = slices.fst.too
+
+  def yaml(implicit ev: Ordering[BandedObservation]) =
+    f"""|
+        |Reference: ${reference}
+        |Mode:      ${mode}
+        |Title:     ${title}
+        |PI:        ${pi}
+        |Partner:   ${partner.fullName}
+        |Award:     ${award.toHours.value}%1.1f
+        |Rank:      ${rank}%1.1f
+        |ToO:       ${too}
+        |
+        |Observations:
+        |${siteSummaries.foldMap(_.yaml)}
+        |""".stripMargin
+
+}
+
+object Summary {
+
+  // no time to make band a proper type, sorry
+  final case class BandedObservation(band: String, obs: Observation)
+
+  // Slight convenience
+  private implicit class ObservationOps(o: Observation) {
+    def ra:  HourAngle = Angle.hourAngle.get(Angle.fromDoubleDegrees(o.target.ra.mag))
+    def dec: Angle     = Angle.fromDoubleDegrees(o.target.dec.mag)
+  }
+
+  // A slice, north or south.
+  final case class Slice(proposal: Proposal) {
+
+    private def bandedObservations(implicit ev: Ordering[BandedObservation]): List[BandedObservation] = {
+      proposal.obsList          .map(BandedObservation("B1/2", _)) ++
+      proposal.band3Observations.map(BandedObservation("B3",   _))
+    } .sorted
+
+    private def obsYaml(bo: BandedObservation): String = {
+      val o     = bo.obs
+      val id    = ObservationDigest.digest(o.p1Observation)
+      val ra    = HourAngle.HMS(o.ra).format
+      val dec   = Declination.fromAngle.getOption(o.dec).map(Declination.fromStringSignedDMS.reverseGet).getOrElse(sys.error(s"unpossible: invalid declination for $bo"))
+      val conds = f"${o.conditions.cc}%-5s ${o.conditions.iq}%-5s ${o.conditions.sb}%-5s ${o.conditions.wv}%-5s "
+      val hrs   = o.time.toHours.value
+      f"  - $id  ${bo.band}%-4s  $hrs%5.1fh  $conds  $ra%16s  $dec%16s  ${o.target.name.orEmpty}\n"
+    }
+
+    def yaml(implicit ev: Ordering[BandedObservation]): String =
+      f"  ${proposal.site.abbreviation}:\n${bandedObservations.foldMap(obsYaml)}\n"
+
+  }
+
+}
+

--- a/modules/main/src/main/scala/Summary.scala
+++ b/modules/main/src/main/scala/Summary.scala
@@ -24,7 +24,6 @@ case class Summary(slices: OneOrTwo[Proposal]) {
 
   val reference = slices.fst.ntac.reference
   val mode      = slices.fst.mode
-  val title     = slices.fst.p1proposal.title
   val pi        = slices.fst.piName.orEmpty
   val partner   = slices.fst.ntac.partner
   val award     = slices.fst.ntac.awardedTime
@@ -35,7 +34,6 @@ case class Summary(slices: OneOrTwo[Proposal]) {
     f"""|
         |Reference: ${reference}
         |Mode:      ${mode}
-        |Title:     ${title}
         |PI:        ${pi}
         |Partner:   ${partner.fullName}
         |Award:     ${award.toHours.value}%1.1f

--- a/modules/main/src/main/scala/SummaryEdit.scala
+++ b/modules/main/src/main/scala/SummaryEdit.scala
@@ -24,10 +24,13 @@ case class SummaryEdit(
   obsEdits:  List[SummaryEdit.Obs]
 ) {
 
-  private def update(os: java.util.List[Observation]): Unit =
+  private def update(os: java.util.List[Observation]): Unit = {
     os.forEach { o =>
       obsEdits.find(_.hash == ObservationDigest.digest(im.Observation(o))).foreach(_ update o)
     }
+    os.removeIf { o => !o.isEnabled() }
+    ()
+  }
 
   private def update(sa: SubmissionAccept): Unit =
     if (sa != null) {
@@ -178,7 +181,8 @@ object SummaryEdit {
       if (t != null) {
         t match {
           case st: SiderealTarget => updateSiderealTarget(st)
-          case _ => throw new ItacException(s"$hash: Edits to ToO and nonsidereal targets must be done in the PIT.")
+          case _ => () // TODO: log
+              // throw new ItacException(s"$hash: Edits to ToO and nonsidereal targets must be done in the PIT.")
         }
       }
 
@@ -187,6 +191,7 @@ object SummaryEdit {
         o.setBand(band)
         updateCondition(o.getCondition)
         updateTarget(o.getTarget)
+        o.setEnabled(name != "DISABLE")
       }
 
   }

--- a/modules/main/src/main/scala/SummaryEdit.scala
+++ b/modules/main/src/main/scala/SummaryEdit.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package itac
 
 import cats.implicits._

--- a/modules/main/src/main/scala/SummaryEdit.scala
+++ b/modules/main/src/main/scala/SummaryEdit.scala
@@ -1,114 +1,141 @@
 package itac
 
 import cats.implicits._
-import edu.gemini.model.p1.immutable._
+import edu.gemini.model.p1.mutable._
+import edu.gemini.model.p1.{ immutable => im }
 import gsp.math.RightAscension
 import gsp.math.Declination
-import edu.gemini.spModel.core.Coordinates
 import edu.gemini.tac.qengine.{ p1 => itac }
 import io.circe.Decoder
 import io.circe.HCursor
-// import gsp.math.Angle
 
-  // Summary edits are applied to a p1.immutable value so we parse into those data types.
-
+/**
+ * It turns out we can't really go back from the immutable model to the mutable one. The PIT must
+ * do some awful things to make it work. Here we're providing an editor for the initial mutable
+ * model we load from disk, before anything else ever sees it.
+ */
 case class SummaryEdit(
   reference: String,
   ranking:   Double,
-  award:     edu.gemini.model.p1.immutable.TimeAmount,
+  award:     edu.gemini.model.p1.mutable.TimeAmount,
   obsEdits:  List[SummaryEdit.Obs]
 ) {
 
-  // I'm too tired to do this with lenses
-
-  private def update(os: List[Observation]): List[Observation] =
-    os.map { o =>
-      obsEdits.find(_.hash == ObservationDigest.digest(o)).fold(o)(_ update o)
+  private def update(os: java.util.List[Observation]): Unit =
+    os.forEach { o =>
+      obsEdits.find(_.hash == ObservationDigest.digest(im.Observation(o))).foreach(_ update o)
     }
 
-  private def update(sa: SubmissionAccept): SubmissionAccept =
-    sa.copy(ranking = ranking, recommended = award)
-
-  private def update(sd: SubmissionDecision): SubmissionDecision =
-    sd.copy(decision = sd.decision.map(update))
-
-  private def update(sr: SubmissionResponse): SubmissionResponse =
-    sr.copy(decision = sr.decision.map(update))
-
-  private def update(ns: NgoSubmission): NgoSubmission =
-    ns.copy(response = ns.response.map(update))
-
-  private def update(es: ExchangeSubmission): ExchangeSubmission =
-    es.copy(response = es.response.map(update))
-
-  private def update(ss: SpecialSubmission): SpecialSubmission =
-    ss.copy(response = ss.response.map(update))
-
-  private def update(lps: LargeProgramSubmission): LargeProgramSubmission =
-    lps.copy(response = lps.response.map(update))
-
-  private def update(sips: SubaruIntensiveProgramSubmission): SubaruIntensiveProgramSubmission =
-    sips.copy(response = sips.response.map(update))
-
-  private def update(fts: FastTurnaroundSubmission): FastTurnaroundSubmission =
-    fts.copy(response = fts.response.map(update))
-
-  // we assume only one submission has a response
-  private def update(e: Either[List[NgoSubmission], ExchangeSubmission]): Either[List[NgoSubmission], ExchangeSubmission] =
-    e.bimap(ns => ns.map(update), update)
-
-  private def update(pc: QueueProposalClass): QueueProposalClass =
-    pc.copy(subs = update(pc.subs))
-
-  private def update(pc: ClassicalProposalClass): ClassicalProposalClass =
-    pc.copy(subs = update(pc.subs))
-
-  private def update(pc: SpecialProposalClass): SpecialProposalClass =
-    pc.copy(sub = update(pc.sub))
-
-  private def update(pc: ExchangeProposalClass): ExchangeProposalClass =
-    pc.copy(subs = pc.subs.map(update))
-
-  private def update(pc: LargeProgramClass): LargeProgramClass =
-    pc.copy(sub = update(pc.sub))
-
-  private def update(pc: SubaruIntensiveProgramClass): SubaruIntensiveProgramClass =
-    pc.copy(sub = update(pc.sub))
-
-  private def update(ft: FastTurnaroundProgramClass): FastTurnaroundProgramClass =
-    ft.copy(sub = update(ft.sub))
-
-  // N.B. let's not overload here because it will spin if don't implement a case above.
-  private def updatePC(pc: ProposalClass): ProposalClass =
-    pc match {
-      case c: QueueProposalClass => update(c)
-      case c: ClassicalProposalClass => update(c)
-      case c: SpecialProposalClass => update(c)
-      case c: ExchangeProposalClass => update(c)
-      case c: LargeProgramClass => update(c)
-      case c: SubaruIntensiveProgramClass => update(c)
-      case c: FastTurnaroundProgramClass => update(c)
+  private def update(sa: SubmissionAccept): Unit =
+    if (sa != null) {
+      sa.setRanking(BigDecimal(ranking).bigDecimal)
+      sa.setRecommend(award)
     }
 
-  def update(p: Proposal): Proposal = {
-    // TODO: ensure the reference is right!
-    p.copy(
-      proposalClass = updatePC(p.proposalClass),
-      observations  = update(p.observations)
-    )
-  }
+  private def update(sr: SubmissionResponse): Unit =
+    if (sr != null) {
+      update(sr.getAccept())
+    }
+
+  private def update(ns: NgoSubmission): Unit =
+    if (ns != null) {
+      update(ns.getResponse())
+    }
+
+  private def update(es: ExchangeSubmission): Unit =
+    if (es != null) {
+      update(es.getResponse())
+    }
+
+  private def update(ss: SpecialSubmission): Unit =
+    if (ss != null) {
+      update(ss.getResponse())
+    }
+
+  private def update(lps: LargeProgramSubmission): Unit =
+    if (lps != null) {
+      update(lps.getResponse())
+    }
+
+  private def update(sips: SubaruIntensiveProgramSubmission): Unit =
+    if (sips != null) {
+    update(sips.getResponse())
+    }
+
+  private def update(fts: FastTurnaroundSubmission): Unit =
+    if (fts != null) {
+      update(fts.getResponse())
+    }
+
+  private def update(pc: QueueProposalClass): Unit =
+    if (pc != null) {
+      update(pc.getExchange())
+      Option(pc.getNgo()).foreach(_.forEach(update))
+    }
+
+  private def update(pc: ClassicalProposalClass): Unit =
+    if (pc != null) {
+      Option(pc.getNgo()).foreach(_.forEach(update))
+      update(pc.getExchange())
+    }
+
+  private def update(pc: SpecialProposalClass): Unit =
+    if (pc != null) {
+      update(pc.getSubmission())
+    }
+
+  private def update(pc: ExchangeProposalClass): Unit =
+    if (pc != null) {
+      Option(pc.getNgo()).foreach(_.forEach(update))
+    }
+
+  private def update(pc: LargeProgramClass): Unit =
+    if (pc != null) {
+      update(pc.getSubmission())
+    }
+
+  private def update(pc: SubaruIntensiveProgramClass): Unit =
+    if (pc != null) {
+      update(pc.getSubmission())
+    }
+
+  private def update(ft: FastTurnaroundProgramClass): Unit =
+    if (ft != null) {
+      update(ft.getSubmission())
+    }
+
+  // // N.B. let's not overload here because it will spin if don't implement a case above.
+  private def updatePC(pc: ProposalClassChoice): Unit =
+    if (pc != null) {
+      update(pc.getClassical())
+      update(pc.getExchange())
+      update(pc.getFastTurnaround())
+      update(pc.getLarge())
+      update(pc.getQueue())
+      update(pc.getSip())
+      update(pc.getSpecial())
+      update(pc.getFastTurnaround())
+    }
+
+  def update(p: Proposal): Unit =
+    try {
+      update(p.getObservations().getObservation())
+      updatePC(p.getProposalClass())
+    } catch {
+      case e: Exception => throw new ItacException(s"$reference: ${e.getMessage}")
+    }
 
 }
 
 object SummaryEdit {
 
-  implicit val DecoderSummaryEdit: Decoder[SummaryEdit] =
+  implicit val DecoderSummaryEdit2: Decoder[SummaryEdit] =
     new Decoder[SummaryEdit] {
       def apply(c: HCursor): Decoder.Result[SummaryEdit] =
         for {
           ref   <- c.downField("Reference").as[String]
           rank  <- c.downField("Rank").as[Double]
-          award <- c.downField("Award").as[Double].map(TimeAmount(_, TimeUnit.HR))
+          award <- c.downField("Award").as[BigDecimal].map { d => val ta = new TimeAmount(); ta.setUnits(TimeUnit.HR); ta.setValue(d.bigDecimal); ta }
           obs   <- c.downField("Observations").as[Map[String, List[Obs]]].map(_.values.toList.combineAll)
         } yield SummaryEdit(ref, rank, award, obs)
     }
@@ -117,7 +144,6 @@ object SummaryEdit {
   case class Obs(
     hash: String,
     band: Band,
-    time: TimeAmount,
     cc:   CloudCover,
     iq:   ImageQuality,
     sb:   SkyBackground,
@@ -127,33 +153,38 @@ object SummaryEdit {
     name: String
   ) {
 
-    private def updateConditions(c: Condition): Condition =
-      c.copy(cc = cc, iq = iq, wv = wv)
-
-    private def coords: Coordinates =
-      Coordinates.fromDegrees(
-        ra.toAngle.toDoubleDegrees,
-        dec.toAngle.toDoubleDegrees
-      ).getOrElse(sys.error(s"Invalid coords: $ra $dec"))
-
-    private def updateSiderealTarget(t: SiderealTarget): SiderealTarget =
-      t.copy(name = name, coords = coords)
-
-    private def updateTarget(t: Target): SiderealTarget =
-      t match {
-        case st: SiderealTarget => updateSiderealTarget(st)
-        case _                  => throw new ItacException("Edits to ToO and nonsidereal targets must be done in the PIT.")
+    private def updateCondition(c: Condition): Unit =
+      if (c != null) {
+        c.setCc(cc)
+        c.setIq(iq)
+        c.setSb(sb)
+        c.setWv(wv)
       }
 
-    def update(o: Observation): Observation = {
-      require(ObservationDigest.digest(o) == hash, "Obs digests don't match.")
-      o.copy(
-        band      = band,
-        progTime  = Some(time),
-        condition = o.condition.map(updateConditions),
-        target    = o.target.map(updateTarget)
-      )
+    private def updateSiderealTarget(t: SiderealTarget): Unit = {
+      t.setName(name)
+      t.setDegDeg {
+        val cs = new DegDegCoordinates
+        cs.setRa(BigDecimal(ra.toAngle.toDoubleDegrees).bigDecimal)
+        cs.setDec(BigDecimal(dec.toAngle.toDoubleDegrees).bigDecimal)
+        cs
+      }
     }
+
+    private def updateTarget(t: Target): Unit =
+      if (t != null) {
+        t match {
+          case st: SiderealTarget => updateSiderealTarget(st)
+          case _ => throw new ItacException(s"$hash: Edits to ToO and nonsidereal targets must be done in the PIT.")
+        }
+      }
+
+    def update(o: Observation): Unit =
+      if (o != null) {
+        o.setBand(band)
+        updateCondition(o.getCondition)
+        updateTarget(o.getTarget)
+      }
 
   }
 
@@ -169,55 +200,52 @@ object SummaryEdit {
         case _      => Left(s"Invalid band: $s")
       }
 
-    private def timeFromString(s: String): Either[String, TimeAmount] =
-      (s.dropRight(1), s.takeRight(1)) match {
-        case (s, "h") => Either.catchNonFatal(TimeAmount(s.toDouble, TimeUnit.HR)).leftMap(_ => s"Invalid time: $s")
-        case _        => Left(s"Invalid time: $s")
-       }
-
     private def ccFromString(s: String): Either[String, CloudCover] =
       PartialFunction.condOpt(s)(Map(
-        itac.CloudCover.CC50.toString  -> CloudCover.BEST,
-        itac.CloudCover.CC70.toString  -> CloudCover.CC70,
-        itac.CloudCover.CC80.toString  -> CloudCover.CC80,
-        itac.CloudCover.CCAny.toString -> CloudCover.ANY,
+        itac.CloudCover.CC50.toString  -> CloudCover.cc50,
+        itac.CloudCover.CC70.toString  -> CloudCover.cc70,
+        itac.CloudCover.CC80.toString  -> CloudCover.cc80,
+        itac.CloudCover.CCAny.toString -> CloudCover.cc100,
       )).toRight(s"Invalid CC: $s")
 
     private def iqFromString(s: String): Either[String, ImageQuality] =
       PartialFunction.condOpt(s)(Map(
-        itac.ImageQuality.IQ20.toString  -> ImageQuality.BEST,
-        itac.ImageQuality.IQ70.toString  -> ImageQuality.IQ70,
-        itac.ImageQuality.IQ85.toString  -> ImageQuality.IQ85,
-        itac.ImageQuality.IQAny.toString -> ImageQuality.IQANY,
+        itac.ImageQuality.IQ20.toString  -> ImageQuality.iq20,
+        itac.ImageQuality.IQ70.toString  -> ImageQuality.iq70,
+        itac.ImageQuality.IQ85.toString  -> ImageQuality.iq85,
+        itac.ImageQuality.IQAny.toString -> ImageQuality.iq100,
       )).toRight(s"Invalid IQ: $s")
 
     private def sbFromString(s: String): Either[String, SkyBackground] =
       PartialFunction.condOpt(s)(Map(
-        itac.SkyBackground.SB20.toString  -> SkyBackground.BEST,
-        itac.SkyBackground.SBAny.toString -> SkyBackground.ANY,
+        itac.SkyBackground.SB20.toString  -> SkyBackground.sb20,
+        itac.SkyBackground.SB50.toString  -> SkyBackground.sb50,
+        itac.SkyBackground.SB80.toString  -> SkyBackground.sb80,
+        itac.SkyBackground.SBAny.toString -> SkyBackground.sb100,
       )).toRight(s"Invalid SB: $s")
 
     private def wvFromString(s: String): Either[String, WaterVapor] =
       PartialFunction.condOpt(s)(Map(
-        itac.WaterVapor.WV20.toString  -> WaterVapor.BEST,
-        itac.WaterVapor.WVAny.toString -> WaterVapor.ANY,
+        itac.WaterVapor.WV20.toString  -> WaterVapor.wv20,
+        itac.WaterVapor.WV50.toString  -> WaterVapor.wv50,
+        itac.WaterVapor.WV80.toString  -> WaterVapor.wv80,
+        itac.WaterVapor.WVAny.toString -> WaterVapor.wv100,
       )).toRight(s"Invalid SB: $s")
 
     //  bcecb5a8  B1/2    0.3h  CC70  SB70  SBAny WVAny    20:34:13.370299   28:09:50.826099  my name
     def fromString(s: String): Either[String, Obs] =
       s.trim.split("\\s+", 10) match {
-        case Array(hash, band, time, cc, iq, sb, wv, ra, dec, name) =>
+        case Array(hash, band, _, cc, iq, sb, wv, ra, dec, name) =>
           for {
             h <- hashFromString(hash)
             b <- bandFromString(band)
-            t <- timeFromString(time)
             c <- ccFromString(cc)
             i <- iqFromString(iq)
             s <- sbFromString(sb)
             w <- wvFromString(wv)
             r <- RightAscension.fromStringHMS.getOption(ra).toRight(s"Invalid RA: $ra")
             d <- Declination.fromStringSignedDMS.getOption(dec).toRight(s"Invalid Dec: $dec")
-          } yield Obs(h, b, t, c, i, s, w, r, d, name)
+          } yield Obs(h, b, c, i, s, w, r, d, name)
         case _ => Left("Not enough fields. Expected hash, band, time, cc, iq, sb, wv, ra, dec, name")
       }
 

--- a/modules/main/src/main/scala/SummaryEdit.scala
+++ b/modules/main/src/main/scala/SummaryEdit.scala
@@ -1,0 +1,232 @@
+package itac
+
+import cats.implicits._
+import edu.gemini.model.p1.immutable._
+import gsp.math.RightAscension
+import gsp.math.Declination
+import edu.gemini.spModel.core.Coordinates
+import edu.gemini.tac.qengine.{ p1 => itac }
+import io.circe.Decoder
+import io.circe.HCursor
+// import gsp.math.Angle
+
+  // Summary edits are applied to a p1.immutable value so we parse into those data types.
+
+case class SummaryEdit(
+  reference: String,
+  ranking:   Double,
+  award:     edu.gemini.model.p1.immutable.TimeAmount,
+  obsEdits:  List[SummaryEdit.Obs]
+) {
+
+  // I'm too tired to do this with lenses
+
+  private def update(os: List[Observation]): List[Observation] =
+    os.map { o =>
+      obsEdits.find(_.hash == ObservationDigest.digest(o)).fold(o)(_ update o)
+    }
+
+  private def update(sa: SubmissionAccept): SubmissionAccept =
+    sa.copy(ranking = ranking, recommended = award)
+
+  private def update(sd: SubmissionDecision): SubmissionDecision =
+    sd.copy(decision = sd.decision.map(update))
+
+  private def update(sr: SubmissionResponse): SubmissionResponse =
+    sr.copy(decision = sr.decision.map(update))
+
+  private def update(ns: NgoSubmission): NgoSubmission =
+    ns.copy(response = ns.response.map(update))
+
+  private def update(es: ExchangeSubmission): ExchangeSubmission =
+    es.copy(response = es.response.map(update))
+
+  private def update(ss: SpecialSubmission): SpecialSubmission =
+    ss.copy(response = ss.response.map(update))
+
+  private def update(lps: LargeProgramSubmission): LargeProgramSubmission =
+    lps.copy(response = lps.response.map(update))
+
+  private def update(sips: SubaruIntensiveProgramSubmission): SubaruIntensiveProgramSubmission =
+    sips.copy(response = sips.response.map(update))
+
+  private def update(fts: FastTurnaroundSubmission): FastTurnaroundSubmission =
+    fts.copy(response = fts.response.map(update))
+
+  // we assume only one submission has a response
+  private def update(e: Either[List[NgoSubmission], ExchangeSubmission]): Either[List[NgoSubmission], ExchangeSubmission] =
+    e.bimap(ns => ns.map(update), update)
+
+  private def update(pc: QueueProposalClass): QueueProposalClass =
+    pc.copy(subs = update(pc.subs))
+
+  private def update(pc: ClassicalProposalClass): ClassicalProposalClass =
+    pc.copy(subs = update(pc.subs))
+
+  private def update(pc: SpecialProposalClass): SpecialProposalClass =
+    pc.copy(sub = update(pc.sub))
+
+  private def update(pc: ExchangeProposalClass): ExchangeProposalClass =
+    pc.copy(subs = pc.subs.map(update))
+
+  private def update(pc: LargeProgramClass): LargeProgramClass =
+    pc.copy(sub = update(pc.sub))
+
+  private def update(pc: SubaruIntensiveProgramClass): SubaruIntensiveProgramClass =
+    pc.copy(sub = update(pc.sub))
+
+  private def update(ft: FastTurnaroundProgramClass): FastTurnaroundProgramClass =
+    ft.copy(sub = update(ft.sub))
+
+  // N.B. let's not overload here because it will spin if don't implement a case above.
+  private def updatePC(pc: ProposalClass): ProposalClass =
+    pc match {
+      case c: QueueProposalClass => update(c)
+      case c: ClassicalProposalClass => update(c)
+      case c: SpecialProposalClass => update(c)
+      case c: ExchangeProposalClass => update(c)
+      case c: LargeProgramClass => update(c)
+      case c: SubaruIntensiveProgramClass => update(c)
+      case c: FastTurnaroundProgramClass => update(c)
+    }
+
+  def update(p: Proposal): Proposal = {
+    // TODO: ensure the reference is right!
+    p.copy(
+      proposalClass = updatePC(p.proposalClass),
+      observations  = update(p.observations)
+    )
+  }
+
+}
+
+object SummaryEdit {
+
+  implicit val DecoderSummaryEdit: Decoder[SummaryEdit] =
+    new Decoder[SummaryEdit] {
+      def apply(c: HCursor): Decoder.Result[SummaryEdit] =
+        for {
+          ref   <- c.downField("Reference").as[String]
+          rank  <- c.downField("Rank").as[Double]
+          award <- c.downField("Award").as[Double].map(TimeAmount(_, TimeUnit.HR))
+          obs   <- c.downField("Observations").as[Map[String, List[Obs]]].map(_.values.toList.combineAll)
+        } yield SummaryEdit(ref, rank, award, obs)
+    }
+
+  // These need to be applied to a p1.immutable value so we parse into those data types.
+  case class Obs(
+    hash: String,
+    band: Band,
+    time: TimeAmount,
+    cc:   CloudCover,
+    iq:   ImageQuality,
+    sb:   SkyBackground,
+    wv:   WaterVapor,
+    ra:   RightAscension,
+    dec:  Declination,
+    name: String
+  ) {
+
+    private def updateConditions(c: Condition): Condition =
+      c.copy(cc = cc, iq = iq, wv = wv)
+
+    private def coords: Coordinates =
+      Coordinates.fromDegrees(
+        ra.toAngle.toDoubleDegrees,
+        dec.toAngle.toDoubleDegrees
+      ).getOrElse(sys.error(s"Invalid coords: $ra $dec"))
+
+    private def updateSiderealTarget(t: SiderealTarget): SiderealTarget =
+      t.copy(name = name, coords = coords)
+
+    private def updateTarget(t: Target): SiderealTarget =
+      t match {
+        case st: SiderealTarget => updateSiderealTarget(st)
+        case _                  => throw new ItacException("Edits to ToO and nonsidereal targets must be done in the PIT.")
+      }
+
+    def update(o: Observation): Observation = {
+      require(ObservationDigest.digest(o) == hash, "Obs digests don't match.")
+      o.copy(
+        band      = band,
+        progTime  = Some(time),
+        condition = o.condition.map(updateConditions),
+        target    = o.target.map(updateTarget)
+      )
+    }
+
+  }
+
+  object Obs {
+
+    private def hashFromString(s: String): Either[String, String] =
+       Either.catchNonFatal(BigInt(s, 16)).leftMap(_ => s"Invalid hash: $s").as(s)
+
+    private def bandFromString(s: String): Either[String, Band] =
+      s match {
+        case "B1/2" => Right(Band.BAND_1_2)
+        case "B3"   => Right(Band.BAND_3)
+        case _      => Left(s"Invalid band: $s")
+      }
+
+    private def timeFromString(s: String): Either[String, TimeAmount] =
+      (s.dropRight(1), s.takeRight(1)) match {
+        case (s, "h") => Either.catchNonFatal(TimeAmount(s.toDouble, TimeUnit.HR)).leftMap(_ => s"Invalid time: $s")
+        case _        => Left(s"Invalid time: $s")
+       }
+
+    private def ccFromString(s: String): Either[String, CloudCover] =
+      PartialFunction.condOpt(s)(Map(
+        itac.CloudCover.CC50.toString  -> CloudCover.BEST,
+        itac.CloudCover.CC70.toString  -> CloudCover.CC70,
+        itac.CloudCover.CC80.toString  -> CloudCover.CC80,
+        itac.CloudCover.CCAny.toString -> CloudCover.ANY,
+      )).toRight(s"Invalid CC: $s")
+
+    private def iqFromString(s: String): Either[String, ImageQuality] =
+      PartialFunction.condOpt(s)(Map(
+        itac.ImageQuality.IQ20.toString  -> ImageQuality.BEST,
+        itac.ImageQuality.IQ70.toString  -> ImageQuality.IQ70,
+        itac.ImageQuality.IQ85.toString  -> ImageQuality.IQ85,
+        itac.ImageQuality.IQAny.toString -> ImageQuality.IQANY,
+      )).toRight(s"Invalid IQ: $s")
+
+    private def sbFromString(s: String): Either[String, SkyBackground] =
+      PartialFunction.condOpt(s)(Map(
+        itac.SkyBackground.SB20.toString  -> SkyBackground.BEST,
+        itac.SkyBackground.SBAny.toString -> SkyBackground.ANY,
+      )).toRight(s"Invalid SB: $s")
+
+    private def wvFromString(s: String): Either[String, WaterVapor] =
+      PartialFunction.condOpt(s)(Map(
+        itac.WaterVapor.WV20.toString  -> WaterVapor.BEST,
+        itac.WaterVapor.WVAny.toString -> WaterVapor.ANY,
+      )).toRight(s"Invalid SB: $s")
+
+    //  bcecb5a8  B1/2    0.3h  CC70  SB70  SBAny WVAny    20:34:13.370299   28:09:50.826099  my name
+    def fromString(s: String): Either[String, Obs] =
+      s.trim.split("\\s+", 10) match {
+        case Array(hash, band, time, cc, iq, sb, wv, ra, dec, name) =>
+          for {
+            h <- hashFromString(hash)
+            b <- bandFromString(band)
+            t <- timeFromString(time)
+            c <- ccFromString(cc)
+            i <- iqFromString(iq)
+            s <- sbFromString(sb)
+            w <- wvFromString(wv)
+            r <- RightAscension.fromStringHMS.getOption(ra).toRight(s"Invalid RA: $ra")
+            d <- Declination.fromStringSignedDMS.getOption(dec).toRight(s"Invalid Dec: $dec")
+          } yield Obs(h, b, t, c, i, s, w, r, d, name)
+        case _ => Left("Not enough fields. Expected hash, band, time, cc, iq, sb, wv, ra, dec, name")
+      }
+
+    implicit val DecoderObs: Decoder[Obs] =
+      Decoder.decodeString.emap(fromString)
+
+  }
+
+}
+
+
+

--- a/modules/main/src/main/scala/Workspace.scala
+++ b/modules/main/src/main/scala/Workspace.scala
@@ -91,7 +91,6 @@ object Workspace {
   val EmailTemplateDir = Paths.get("email_templates")
   val ProposalDir      = Paths.get("proposals")
   val EditsDir         = Paths.get("edits")
-  val EditsFile        = Paths.get("edits.yaml")
 
   val WorkspaceDirs: List[Path] =
     List(EmailTemplateDir, ProposalDir, EditsDir)

--- a/modules/main/src/main/scala/operation/Init.scala
+++ b/modules/main/src/main/scala/operation/Init.scala
@@ -34,7 +34,6 @@ object Init {
             _ <- Workspace.WorkspaceDirs.traverse(ws.mkdirs(_))
             _ <- EmailTemplateRef.all.traverse(ws.extractEmailTemplate)
             _ <- ws.writeText(Workspace.Default.CommonConfigFile, initialCommonConfig(semester))
-            _ <- ws.writeText(Workspace.EditsFile, initialEdits)
             _ <- Site.values.toList.traverse(s => ws.writeText(Workspace.Default.queueConfigFile(s), initialSiteConfig(s)))
             _ <- Site.values.toList.traverse(s => Rollover(s, None).run(ws, log, b))
           } yield ExitCode.Success
@@ -202,35 +201,5 @@ object Init {
         |# Queue filling limit (percentage over 80).
         |overfill: 5
         |""".stripMargin
-
-  def initialEdits: String =
-  s"""|
-      |# This is the edits file, shared by all queues. You can change any values here, as long as the
-      |# format remains the same. You can also add comment lines.
-      |#
-      |# Each edit is keyed by the proposal reference id, followed by one or more edits:
-      |#
-      |#   itacComment  - use this to add a comment
-      |#
-      |#   observations - a list of observation edits keyed by observation hash (provided in error messages
-      |#                  when queue filling fails). Possible edits are:
-      |#                    Disable - disable the
-      |#
-      |# An example definition might look like this:
-      |#
-      |#   edits:
-      |#
-      |#     US-2020A-129:
-      |#       itacComment: We had to take some hours away, sorry.
-      |#
-      |#     AR-2020A-006:
-      |#       itacComment: Excellent proposal.
-      |#       observations:
-      |#         bd42d3b6: Disable
-      |#         5bc82e30: Disable
-      |
-      |edits:
-      |  # no edits yet
-      |""".stripMargin
 
 }

--- a/modules/main/src/main/scala/operation/Summarize.scala
+++ b/modules/main/src/main/scala/operation/Summarize.scala
@@ -87,7 +87,7 @@ object Summarize {
               |# - WV    as ${WaterVapor.values.mkString(", ")}
               |# - RA    as HMS
               |# - Dec   as Signed DMS(signed dms)
-              |# - Name  as Text
+              |# - Name  as Text, set to DISABLE to disable observation
               |""".stripMargin
 
         if (edit) {

--- a/modules/main/src/main/scala/util/OneOrTwo.scala
+++ b/modules/main/src/main/scala/util/OneOrTwo.scala
@@ -1,0 +1,53 @@
+package itac.util
+
+import cats._
+import cats.implicits._
+
+sealed trait OneOrTwo[A] extends Product with Serializable {
+
+  def fold[B](f: A => B, g: (A, A) => B): B =
+    this match {
+      case OneOrTwo.One(a)    => f(a)
+      case OneOrTwo.Two(a, b) => g(a, b)
+    }
+
+  def fst: A = fold(identity, (a, _) => a)
+  def snd: Option[A] = fold(_ => none, (_, a) => a.some)
+
+}
+
+object OneOrTwo {
+
+  final case class One[A](a: A)       extends OneOrTwo[A]
+  final case class Two[A](a: A, b: A) extends OneOrTwo[A]
+
+  def apply[A](a: A):       OneOrTwo[A] = One(a)
+  def apply[A](a: A, b: A): OneOrTwo[A] = Two(a, b)
+
+  def fromFoldable[F[_]: Foldable, A](fa: F[A]): Option[OneOrTwo[A]] =
+    fa.toList match {
+      case List(a)    => One(a).some
+      case List(a, b) => Two(a, b).some
+      case _          => none
+    }
+
+  implicit val TraverseOneOrTwo: Traverse[OneOrTwo] =
+    new Traverse[OneOrTwo] {
+
+      override def map[A, B](fa: OneOrTwo[A])(f: A => B): OneOrTwo[B] =
+        fa.fold(a => OneOrTwo(f(a)), (a, b) => OneOrTwo(f(a), f(b)))
+
+      def foldLeft[A, B](fa: OneOrTwo[A], b: B)(f: (B, A) => B): B =
+        fa.fold(a => f(b, a), (a, a1) => f(f(b, a), a1))
+
+      def foldRight[A, B](fa: OneOrTwo[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        fa.fold(a => f(a, lb), (a, a1) => f(a, f(a1, lb)))
+
+      def traverse[G[_]: Applicative, A, B](fa: OneOrTwo[A])(f: A => G[B]): G[OneOrTwo[B]] =
+        fa.fold(a => f(a).map(OneOrTwo(_)), (a, a1) => (f(a), f(a1)).mapN(OneOrTwo(_, _)))
+
+    }
+
+}
+
+

--- a/modules/main/src/main/scala/util/OneOrTwo.scala
+++ b/modules/main/src/main/scala/util/OneOrTwo.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package itac.util
 
 import cats._


### PR DESCRIPTION
This provides for minor proposal edits. The workflow is:

- `itac summarize --edit <ref>` to create `edits/<ref>.yaml` which looks just like the normal summary (which has changed a bit to be valid YAML) but has a header that includes brief instruction on allowed edits.
- Edit that file as needed. `itac` will apply those edits whenever the proposal is read.

TODO:

- [x] observation deletion
- [x] better handling for nonsidereal and TOO targets.
- [x] update README