### PR TITLE
group split proposals in queue report, improve duplication report

### DIFF
--- a/modules/main/src/main/scala/QueueResult.scala
+++ b/modules/main/src/main/scala/QueueResult.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package itac
 
 import cats.implicits._

--- a/modules/main/src/main/scala/QueueResult.scala
+++ b/modules/main/src/main/scala/QueueResult.scala
@@ -1,0 +1,46 @@
+package itac
+
+import cats.implicits._
+import edu.gemini.tac.qengine.api.QueueCalc
+import cats.data.NonEmptyList
+import edu.gemini.tac.qengine.p1.Proposal
+import edu.gemini.spModel.core.ProgramId
+import edu.gemini.tac.qengine.p1.QueueBand
+import edu.gemini.tac.qengine.ctx.Partner
+
+/** The final queue result, with joint proposal grouped and program IDs assigned. */
+final case class QueueResult(queueCalc: QueueCalc) {
+  import QueueResult.Entry
+  import queueCalc.context.{ site, semester }
+
+  /** Sort by PI last name, reversed, using TAC references as a tie-breaker. */
+  private def shuffle(ps: List[NonEmptyList[Proposal]]): List[NonEmptyList[Proposal]] =
+    ps.sortBy { nel => (nel.head.piName.orEmpty.reverse, nel.head.id.reference) }
+
+  /** Group joints together by finding proposals with the same PI and title. */
+  private def groupJoints(ps: List[Proposal]): List[NonEmptyList[Proposal]] =
+    ps.groupBy(p => (p.piName, p.p1proposal.title)).values.toList.map(NonEmptyList.fromList(_).get)
+
+  def entries(qb: QueueBand): List[Entry] = {
+    val ps = queueCalc.queue.bandedQueue.getOrElse(qb, Nil)
+    val gs = shuffle(groupJoints(ps))
+    gs.zipWithIndex.map { case (nel, n) =>
+      Entry(nel, ProgramId.parse(s"${site.abbreviation}-${semester}-Q-${100 * qb.number + (n + 1)}"))
+    }
+  }
+
+  def entries(qb: QueueBand, partner: Partner): List[Entry] =
+    entries(qb).mapFilter { e =>
+      e.proposals
+       .filter(_.ntac.partner == partner)
+       .toNel
+       .map(Entry(_, e.programId))
+    }
+
+}
+
+object QueueResult {
+
+  final case class Entry(proposals: NonEmptyList[Proposal], programId: ProgramId)
+
+}

--- a/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
+++ b/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
@@ -83,7 +83,7 @@ class TargetDuplicationChecker(proposals: List[Proposal], val tolerance: Angle =
 
     val infos: List[TargetInfo] =
       for {
-        p <- proposals
+        p <- proposals.groupBy(p => (p.piName, p.p1proposal.title)).values.map(_.head).toList
         t <- (p.obsList ++ p.band3Observations).map(_.target).distinct
         if (t.ra.mag != 0 || t.dec.mag != 0)
       } yield TargetInfo(p.id.reference, t)


### PR DESCRIPTION
Two unrelated changes, sorry.

- The queue report now groups split proposals (including but not limited to joints) in the Queue report and assigns them all the same program id.
- The duplication check removes all clusters where every program has the same PI (by email address) and adds columns for the PI and blueprint names.