### PR TITLE
fix bug in b3 engine params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ work2
 hawaii
 2020B
 *.worksheet.sc
+marie

--- a/modules/engine/src/main/scala/impl/QueueCalcStage.scala
+++ b/modules/engine/src/main/scala/impl/QueueCalcStage.scala
@@ -98,7 +98,7 @@ object QueueCalcStage {
         }
       val hackedQueue = phase12queue.copy(queueTime = hackedQueueTime)
       val iter = BlockIterator(config.partners, phase12queue.queueTime.partnerQuanta, config.partnerSeq.sequence, grouped, _.band3Observations)
-      new Params(Category.B3, hackedQueue, iter, _.obsList, phase12bins.copy(cat = Category.B3), phase12log)
+      new Params(Category.B3, hackedQueue, iter, _.band3Observations, phase12bins.copy(cat = Category.B3), phase12log)
     }
 
   }


### PR DESCRIPTION
This fixes a serious bug in the handling of Band3 proposals. If the engine had to backtrack it would switch from the B3 observations back to the B1/2 observations because I was passing wrong "activeList" function. Luckily Marie spotted this. Yikes.