### PR TITLE
per-band-category overfill config

### DIFF
--- a/modules/engine/src/main/scala/impl/QueueCalcStage.scala
+++ b/modules/engine/src/main/scala/impl/QueueCalcStage.scala
@@ -67,7 +67,7 @@ object QueueCalcStage {
           val delegate = phase12queue.queueTime
           def fullPartnerTime: PartnerTime = delegate.fullPartnerTime
           def bandPercentages: QueueBandPercentages = delegate.bandPercentages
-          def partnerOverfillAllowance: Option[Percent] = delegate.partnerOverfillAllowance
+          def overfillAllowance(cat: QueueBand.Category) = delegate.overfillAllowance(cat)
           def full: Time = delegate.full
           def band1End: Time = phase12queue.usedTime(QueueBand.QBand1)
           def band2End: Time = phase12queue.usedTime(Category.B1_2)

--- a/modules/engine/src/main/scala/impl/QueueEngine.scala
+++ b/modules/engine/src/main/scala/impl/QueueEngine.scala
@@ -219,7 +219,7 @@ object QueueEngine extends edu.gemini.tac.qengine.api.QueueEngine {
 
           // Within a given partner we can map used time to band.
           def band(t: Time): QueueBand = {
-            val b1 = queueTime(QueueBand.QBand1, pa).percent(105)
+            val b1 = queueTime(QueueBand.QBand1, pa) // exactly. we never overfill band 1
 
             // NOTE: the following doesn't work because the engine sometimes overfills slightly past
             // the limit. In these cases we *can't* push the last proposal to B3 because it's using

--- a/modules/engine/src/main/scala/impl/resource/SemesterResource.scala
+++ b/modules/engine/src/main/scala/impl/resource/SemesterResource.scala
@@ -37,9 +37,12 @@ final case class SemesterResource(
     queue.queueTime.partnerOverfillAllowance exists { perc =>
       val partner   = block.prop.ntac.partner
       val used      = queue.usedTime(cat, partner)
-      val allow     = queue.queueTime.fullPartnerTime(partner) * perc
-      val hardlimit = queue.queueTime(cat, partner) + allow
-      (used + block.prop.time) >= hardlimit
+      val softLimit = queue.queueTime(cat, partner)
+      val allowance = softLimit * perc // overfill is per category (B1_2 and B3 are what we're using)
+      val hardlimit = softLimit + allowance
+      val ret = (used + block.prop.time) >= hardlimit
+      println(f"==> used ${used.toHours.value}%5.1f, available = ${softLimit.toHours.value}%5.1f, overfill = ${perc.value.toDouble}%5.1f, percentage = ${(used.toHours.value / softLimit.toHours.value) * 100.0}%5.1f, prop = ${block.prop.ntac.reference}, award = ${block.prop.time.toHours.value}%5.1f, partnerWouldBeOverallocated = ${ret}")
+      ret
     }
 
   private def partnerOverallocated(block: Block, queue: ProposalQueueBuilder): Boolean =

--- a/modules/engine/src/main/scala/impl/resource/SemesterResource.scala
+++ b/modules/engine/src/main/scala/impl/resource/SemesterResource.scala
@@ -34,14 +34,16 @@ final case class SemesterResource(
   // Determines whether including the indicated proposal will overallocate the
   // partner past the limit and allowance.
   private def partnerWouldBeOverallocated(block: Block, queue: ProposalQueueBuilder): Boolean =
-    queue.queueTime.partnerOverfillAllowance exists { perc =>
+    // RCN: the old logic (and many tests) depend on there being NO LIMIT to overfiling if this
+    //      isn't defined, so for now we're leaving this logic. We need to circle back and fix this.
+    queue.queueTime.overfillAllowance(cat).exists { perc =>
       val partner   = block.prop.ntac.partner
       val used      = queue.usedTime(cat, partner)
       val softLimit = queue.queueTime(cat, partner)
       val allowance = softLimit * perc // overfill is per category (B1_2 and B3 are what we're using)
       val hardlimit = softLimit + allowance
       val ret = (used + block.prop.time) >= hardlimit
-      println(f"==> used ${used.toHours.value}%5.1f, available = ${softLimit.toHours.value}%5.1f, overfill = ${perc.value.toDouble}%5.1f, percentage = ${(used.toHours.value / softLimit.toHours.value) * 100.0}%5.1f, prop = ${block.prop.ntac.reference}, award = ${block.prop.time.toHours.value}%5.1f, partnerWouldBeOverallocated = ${ret}")
+      // println(f"==> used ${used.toHours.value}%5.1f, available = ${softLimit.toHours.value}%5.1f, overfill = ${perc.value.toDouble}%5.1f, percentage = ${(used.toHours.value / softLimit.toHours.value) * 100.0}%5.1f, prop = ${block.prop.ntac.reference}, award = ${block.prop.time.toHours.value}%5.1f, partnerWouldBeOverallocated = ${ret}")
       ret
     }
 

--- a/modules/engine/src/main/scala/p1/QueueBand.scala
+++ b/modules/engine/src/main/scala/p1/QueueBand.scala
@@ -13,7 +13,7 @@ abstract sealed class QueueBand(val number: Int) extends Ordered[QueueBand] {
 
 object QueueBand {
 
-  abstract sealed class Category(val name: String, val order: Int) extends Ordered[Category] {
+  abstract sealed class Category(val name: String, val order: Int) extends Ordered[Category] with Product with Serializable {
     // Ordering is a bit arbitrary
     def compare(that: Category): Int = order - that.order
     override def toString: String = name

--- a/modules/engine/src/test/scala/edu/gemini/tac/qengine/queue/time/ExplicitQueueTimeTest.scala
+++ b/modules/engine/src/test/scala/edu/gemini/tac/qengine/queue/time/ExplicitQueueTimeTest.scala
@@ -68,4 +68,11 @@ class ExplicitQueueTimeTest extends PropSpec with org.scalatestplus.scalacheck.C
       }
     }
   }
+
+  property("sum of 1 and 2 = cat1_2") {
+    check { (qt: QueueTime, p: Partner) =>
+      qt(QBand1, p) + qt(QBand2, p) == qt(Category.B1_2, p)
+    }
+  }
+
 }

--- a/modules/main/src/main/scala/codec/QueueBandCategory.scala
+++ b/modules/main/src/main/scala/codec/QueueBandCategory.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package itac.codec
+
+import io.circe._
+import edu.gemini.tac.qengine.p1.QueueBand
+
+trait QueueBandCategoryCodec {
+
+  implicit val KeyDecoderQueueBandCategory: KeyDecoder[QueueBand.Category] =
+    new KeyDecoder[QueueBand.Category] {
+      def apply(key: String): Option[QueueBand.Category] =
+        QueueBand.Category.values.find(_.productPrefix == key)
+    }
+
+}
+
+object queuebandcategory extends QueueBandCategoryCodec

--- a/modules/main/src/main/scala/codec/package.scala
+++ b/modules/main/src/main/scala/codec/package.scala
@@ -17,5 +17,6 @@ package object codec {
        with DecBinSizeCodec
        with RolloverObservationCodec
        with RolloverReportCodec
+       with QueueBandCategoryCodec
 
 }

--- a/modules/main/src/main/scala/config/QueueConfig.scala
+++ b/modules/main/src/main/scala/config/QueueConfig.scala
@@ -16,7 +16,7 @@ import edu.gemini.tac.qengine.p1.QueueBand
 // queue configuration
 final case class QueueConfig(
   site:       Site,
-  overfill:   Option[Percent],
+  overfill:   Map[QueueBand.Category, Percent],
   raBinSize:  RaBinSize,
   decBinSize: DecBinSize,
   hours:      Map[Partner, BandTimes]

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -115,7 +115,6 @@ object Queue {
                 QueueBand.values.foreach { qb =>
                   val q = queueCalc.queue
 
-
                   print(qb.number match {
                     case 1 => Colors.YELLOW
                     case 2 => Colors.GREEN
@@ -134,22 +133,30 @@ object Queue {
                     val used  = q.usedTime(qb, p).toHours.value
                     val avail = q.queueTime(qb, p).toHours.value
                     val pct   = if (avail == 0) 0.0 else (used / avail) * 100
-                    println(f"                                  B${qb.number} Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%%)")
+
+                    if (qb != QueueBand.QBand3) {
+                      println(f"                                  B${qb.number} Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%%)")
+                    }
 
                     // After the Band2 total print an extra B1+B2 total.
                     if (qb == QueueBand.QBand2) {
                       val used  = (q.usedTime(QueueBand.QBand1, p) + q.usedTime(QueueBand.QBand2, p)).toHours.value
                       val avail = (q.queueTime(QueueBand.QBand1, p) + q.queueTime(QueueBand.QBand2, p)).toHours.value
                       val pct   = if (avail == 0) 0.0 else (used / avail) * 100
-                      println(f"                               B1+B2 Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%%)")
+                      println(f"                               B1+B2 Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%% ≤ ${(queueCalc.queue.queueTime.partnerOverfillAllowance.foldMap(_.doubleValue) + 100.0)}%3.1f%%)")
                     }
 
-                    println()
+                    if (qb == QueueBand.QBand3) {
+                      println(f"                                  B${qb.number} Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%% ≤ ${(queueCalc.queue.queueTime.partnerOverfillAllowance.foldMap(_.doubleValue) + 100.0)}%3.1f%%)")
+                    }
 
                   } else {
                     val used = q.usedTime(qb, p).toHours.value
                     println(f"                                  B${qb.number} Total: $used%5.1f h\n")
                   }
+
+                    println()
+
                 }
                 println()
               }

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -143,11 +143,11 @@ object Queue {
                       val used  = (q.usedTime(QueueBand.QBand1, p) + q.usedTime(QueueBand.QBand2, p)).toHours.value
                       val avail = (q.queueTime(QueueBand.QBand1, p) + q.queueTime(QueueBand.QBand2, p)).toHours.value
                       val pct   = if (avail == 0) 0.0 else (used / avail) * 100
-                      println(f"                               B1+B2 Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%% ≤ ${(queueCalc.queue.queueTime.partnerOverfillAllowance.foldMap(_.doubleValue) + 100.0)}%3.1f%%)")
+                      println(f"                               B1+B2 Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%% ≤ ${(queueCalc.queue.queueTime.overfillAllowance(QueueBand.Category.B1_2).foldMap(_.doubleValue) + 100.0)}%3.1f%%)")
                     }
 
                     if (qb == QueueBand.QBand3) {
-                      println(f"                                  B${qb.number} Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%% ≤ ${(queueCalc.queue.queueTime.partnerOverfillAllowance.foldMap(_.doubleValue) + 100.0)}%3.1f%%)")
+                      println(f"                                  B${qb.number} Total: $used%5.1f h/${avail}%5.1f h ($pct%3.1f%% ≤ ${(queueCalc.queue.queueTime.overfillAllowance(QueueBand.Category.B3).foldMap(_.doubleValue) + 100.0)}%3.1f%%)")
                     }
 
                   } else {

--- a/modules/main/src/main/scala/operation/Queue.scala
+++ b/modules/main/src/main/scala/operation/Queue.scala
@@ -167,19 +167,19 @@ object Queue {
 
               List(QueueBand.Category.B1_2, QueueBand.Category.B3).foreach { qc =>
                 println(s"${Colors.BOLD}The following proposals were rejected for $qc.${Colors.RESET}")
-                pids.foreach { pid =>
-                  val p = ps.find(_.id == pid).get
+                pids.toList.flatMap(pid => ps.find(_.id == pid)).sortBy(_.ntac.ranking.num).foreach { p=>
+                  val pid = p.id
                   log.get(pid, qc) match {
                     case None =>
                     case Some(AcceptMessage(_, _, _))          => //println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s 👍")
-                    case Some(m: RejectPartnerOverAllocation)  => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Partner full:"}%-20s ${m.detail}")
-                    case Some(m: RejectNotBand3)               => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Not band 3:"}%-20s ${m.detail}")
-                    case Some(m: RejectNoTime)                 => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"No time awarded:"}%-20s ${m.detail}")
-                    case Some(m: RejectCategoryOverAllocation) => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Category overallocated:"}%-20s ${m.detail}")
-                    case Some(m: RejectTarget)                 => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${m.raDecType + " bin full:"}%-20s ${m.detail} -- ${ObservationDigest.digest(m.obs.p1Observation)}")
-                    case Some(m: RejectConditions)             => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Conditions bin full:"}%-20s ${m.detail} -- ${ObservationDigest.digest(m.obs.p1Observation)}")
-                    case Some(m: RejectOverAllocation)         => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Overallocation"}%-20s ${m.detail}")
-                    case Some(lm)                              => println(f"- ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Miscellaneous"}%-20s ${lm.getClass.getName}")
+                    case Some(m: RejectPartnerOverAllocation)  => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Partner full:"}%-20s ${m.detail}")
+                    case Some(m: RejectNotBand3)               => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Not band 3:"}%-20s ${m.detail}")
+                    case Some(m: RejectNoTime)                 => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"No time awarded:"}%-20s ${m.detail}")
+                    case Some(m: RejectCategoryOverAllocation) => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Category overallocated:"}%-20s ${m.detail}")
+                    case Some(m: RejectTarget)                 => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${m.raDecType + " bin full:"}%-20s ${m.detail} -- ${ObservationDigest.digest(m.obs.p1Observation)}")
+                    case Some(m: RejectConditions)             => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Conditions bin full:"}%-20s ${m.detail} -- ${ObservationDigest.digest(m.obs.p1Observation)}")
+                    case Some(m: RejectOverAllocation)         => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Overallocation"}%-20s ${m.detail}")
+                    case Some(lm)                              => println(f"${p.ntac.ranking.num.orEmpty}%5.1f ${pid.reference}%-20s ${p.piName.orEmpty}%-15s ${"Miscellaneous"}%-20s ${lm.getClass.getName}")
                   }
                 }
                 println()


### PR DESCRIPTION
Previously overfill was considered for all bands together. This changes it such that the queue band **category** determines the overfill allowance. It would be nice to do away with these categories but there's not time to factor them out right now. 

User queue configs needs to change from this:

```yaml
# Queue filling limit (percentage over 80).
overfill: 5
```

to this:

```yaml
# Queue overfill allowance
overfill:
  B1_2: 5
  B3:   10
```

Bands 1 and 2 are allocated together and the proposals are then partitioned into bands 1 and 2. Band 1 will never be overfilled; all of the overfill goes into Band 2.

----

Unrelated, but this PR  also adds the ranking to the queue rejection report.

