### PR TITLE
allow explicit queue assignments

### DIFF
--- a/modules/engine/src/main/scala/api/config/QueueEngineConfig.scala
+++ b/modules/engine/src/main/scala/api/config/QueueEngineConfig.scala
@@ -5,49 +5,16 @@ package edu.gemini.tac.qengine.api.config
 
 import edu.gemini.tac.qengine.ctx.Partner
 import edu.gemini.tac.qengine.p2.rollover.RolloverReport
-
-object QueueEngineConfig {
-
-  /**
-   * Creates a QueueEngineConfig using the given site and semester configuration
-   * but defaulting the partner sequence and restriction configuration.
-   */
-  def apply(
-    partners: List[Partner],
-    binConfig: SiteSemesterConfig,
-    partnerSequence: PartnerSequence,
-    rolloverReport: RolloverReport
-  ): QueueEngineConfig =
-    new QueueEngineConfig(
-      partners,
-      binConfig,
-      partnerSequence,
-      rolloverReport,
-      RestrictionConfig()
-    )
-
-  /**
-   * Creates a QueueEngineConfig with the given site and semester information,
-   * the given partner sequence, and an optionally specified restriction
-   * configuration.
-   */
-  def apply(
-    partners: List[Partner],
-    binConfig: SiteSemesterConfig,
-    partnerSeq: PartnerSequence,
-    rollover: RolloverReport,
-    restrictedBinConfig: RestrictionConfig = RestrictionConfig()
-  ): QueueEngineConfig =
-    new QueueEngineConfig(partners, binConfig, partnerSeq, rollover, restrictedBinConfig)
-}
+import edu.gemini.tac.qengine.p1.QueueBand
 
 /**
  * A combination of configuration required by the Queue Engine.
  */
-final class QueueEngineConfig(
-  val partners: List[Partner],
-  val binConfig: SiteSemesterConfig,
-  val partnerSeq: PartnerSequence,
-  val rollover: RolloverReport,
-  val restrictedBinConfig: RestrictionConfig
+final case class QueueEngineConfig(
+  partners: List[Partner],
+  binConfig: SiteSemesterConfig,
+  partnerSeq: PartnerSequence,
+  rollover: RolloverReport,
+  restrictedBinConfig: RestrictionConfig = RestrictionConfig(),
+  explicitQueueAssignments: Map[String, QueueBand] = Map.empty
 )

--- a/modules/main/src/main/scala/config/QueueConfig.scala
+++ b/modules/main/src/main/scala/config/QueueConfig.scala
@@ -19,7 +19,8 @@ final case class QueueConfig(
   overfill:   Map[QueueBand.Category, Percent],
   raBinSize:  RaBinSize,
   decBinSize: DecBinSize,
-  hours:      Map[Partner, BandTimes]
+  hours:      Map[Partner, BandTimes],
+  explicitAssignments: Option[Map[String, QueueBand]] // to allow missing in YAML
 ) {
 
   object engine {
@@ -49,6 +50,12 @@ final case class QueueConfig(
 
 object QueueConfig {
   import itac.codec.all._
+
+  implicit val DecoderQueueBand: Decoder[QueueBand] =
+    Decoder[Int].emap { n =>
+      QueueBand.values.find(_.number == n).toRight(s"No such queue band: $n")
+    }
+
   implicit val DecoderQueue: Decoder[QueueConfig] = deriveDecoder
 }
 

--- a/modules/main/src/main/scala/operation/AbstractQueueOperation.scala
+++ b/modules/main/src/main/scala/operation/AbstractQueueOperation.scala
@@ -2,6 +2,7 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 package itac
+
 package operation
 
 import cats._
@@ -18,20 +19,6 @@ import edu.gemini.tac.qengine.util.Percent
 import edu.gemini.tac.qservice.impl.shutdown.ShutdownCalc
 import edu.gemini.tac.qengine.api.QueueCalc
 import edu.gemini.tac.qengine.p1.Proposal
-import edu.gemini.tac.qengine.api.queue.ProposalQueue
-// import edu.gemini.tac.qengine.p1.CoreProposal
-// import edu.gemini.tac.qengine.p1.JointProposal
-// import edu.gemini.tac.qengine.p1.JointProposalPart
-import edu.gemini.model.p1.immutable.{ Proposal => P1Proposal }
-import edu.gemini.model.p1.immutable.ItacAccept
-import edu.gemini.model.p1.immutable.Itac
-import edu.gemini.model.p1.immutable.ItacReject
-import edu.gemini.model.p1.immutable.TimeAmount
-import edu.gemini.model.p1.immutable.`package`.TimeUnit
-import itac.config.Edit.lenses._
-import edu.gemini.tac.qengine.p1.CoreProposal
-import edu.gemini.tac.qengine.p1.JointProposal
-import edu.gemini.tac.qengine.p1.JointProposalPart
 
 abstract class AbstractQueueOperation[F[_]](
   qe:             QueueEngine,
@@ -59,7 +46,7 @@ abstract class AbstractQueueOperation[F[_]](
         partners  = partners,
         config    = QueueEngineConfig(
           partners   = partners,
-          partnerSeq = cc.engine.partnerSequence(qc.site),
+        partnerSeq = cc.engine.partnerSequence(qc.site),
           rollover   = rr,
           binConfig  = createConfig(
             ctx        = Context(qc.site, cc.semester),
@@ -72,59 +59,12 @@ abstract class AbstractQueueOperation[F[_]](
             relativeTimeRestrictions = Nil, // TODO
             absoluteTimeRestrictions = Nil, // TODO
             bandRestrictions         = Nil, // TODO
-          )
+          ),
+          explicitQueueAssignments = qc.explicitAssignments.getOrElse(Map.empty)
         ),
       )
 
-      // Now we need to set the Itac information for each proposal's associated p1Proposal.
-      psʹ = ps.map(addOrUpdateItacNode(_, queueCalc.queue))
-
-    } yield (psʹ, queueCalc)
-
-  // Given a Proposal and a ProposalQueue, update the Proposal's p1proposal's Itac element, or add
-  // one if not present.
-  def addOrUpdateItacNode(p: Proposal, q: ProposalQueue): Proposal = {
-
-    // P1Proposal, which should always be present
-    val p1 = p.p1proposal
-
-    // Our decision, based on presence of a queue position.
-    val decision: Either[ItacReject, ItacAccept] =
-      (q.programId(p), q.positionOf(p)).tupled match {
-        case Some((pid, pos)) => Right(ItacAccept(
-          programId = pid.toString,
-          contact   = Some("Bob Dobbs"),                                              // TODO
-          email     = Some("bob@dobbs.com"),                                              // TODO
-          band      = pos.band.number,
-          award     = new TimeAmount(p.time.toHours.value, TimeUnit.HR),
-          rollover  = false                                              // TODO
-        ))
-        case None             => Left(ItacReject)
-        case _                => sys.error("unpossible")
-      }
-
-    // New ITAC node
-    val itac  = p1.proposalClass.itac.getOrElse(Itac(None, None, None))
-    val itacʹ = itac.copy(
-      decision     = Some(decision),
-      ngoAuthority = None // TODO
-    )
-
-    // New P1Proposal
-    val p1ʹ= P1Proposal.itac.set(p1, Some(itacʹ))
-
-    // New Proposal
-    val pʹ = p match {
-      case cp: CoreProposal      => cp.copy(p1proposal = p1ʹ)
-      case jp: JointProposal     => jp.copy(core = jp.core.copy(p1proposal = p1ʹ))
-      case pp: JointProposalPart => pp.copy(core = pp.core.copy(p1proposal = p1ʹ))
-    }
-
-    // Done
-    pʹ
-
-  }
-
+    } yield (ps, queueCalc)
 
   // These methods were lifted from the ITAC web application.
 


### PR DESCRIPTION
This adds an optional section to the queue configuration that allows you to explicitly assign a proposal to a queue band.

```yaml
# Explicit Queue Assignments
explicitAssignments:
  US-2020B-345: 1
  CA-2020B-678: 3
```

The way this works is, after the queue engine completes its work the specified proposals are removed from the queue (if they are there at all) and are [re-]appended to the queue in the specified bands.

Also deleted some cruft.