### PR TITLE
scheduling command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,21 +39,22 @@ lazy val main = project
   .settings(
     name := "itac-main",
     libraryDependencies ++= Seq(
-      "com.monovore"       %% "decline-effect"         % "1.0.0",
-      "com.monovore"       %% "decline"                % "1.0.0",
-      "edu.gemini"         %% "gsp-math"               % "0.1.10",
-      "io.chrisdavenport"  %% "log4cats-slf4j"         % "1.0.1",
-      "io.circe"           %% "circe-core"             % "0.11.1",
-      "io.circe"           %% "circe-generic"          % "0.11.1",
-      "io.circe"           %% "circe-parser"           % "0.11.1",
-      "io.circe"           %% "circe-yaml"             % "0.10.0",
-      "javax.mail"          % "javax.mail-api"         % "1.6.2",
-      "org.apache.velocity" % "velocity-engine-core"   % "2.2",    // save me jeebus
-      "org.slf4j"           % "slf4j-simple"           % "1.7.28",
-      "org.tpolecat"       %% "atto-core"              % "0.7.1",
-      "org.typelevel"      %% "cats-effect"            % "2.0.0",
-      "org.typelevel"      %% "cats-testkit"           % "2.0.0"     % "test",
-      "org.typelevel"      %% "cats-testkit-scalatest" % "1.0.0-RC1" % "test",
+      "com.monovore"         %% "decline-effect"         % "1.0.0",
+      "com.monovore"         %% "decline"                % "1.0.0",
+      "edu.gemini"           %% "gsp-math"               % "0.1.10",
+      "io.chrisdavenport"    %% "log4cats-slf4j"         % "1.0.1",
+      "io.circe"             %% "circe-core"             % "0.11.1",
+      "io.circe"             %% "circe-generic"          % "0.11.1",
+      "io.circe"             %% "circe-parser"           % "0.11.1",
+      "io.circe"             %% "circe-yaml"             % "0.10.0",
+      "javax.mail"            % "javax.mail-api"         % "1.6.2",
+      "org.apache.velocity"   % "velocity-engine-core"   % "2.2",    // save me jeebus
+      "org.slf4j"             % "slf4j-simple"           % "1.7.28",
+      "org.tpolecat"         %% "atto-core"              % "0.7.1",
+      "org.typelevel"        %% "cats-effect"            % "2.0.0",
+      "com.github.davidmoten" % "word-wrap"              % "0.1.6",
+      "org.typelevel"        %% "cats-testkit"           % "2.0.0"     % "test",
+      "org.typelevel"        %% "cats-testkit-scalatest" % "1.0.0-RC1" % "test",
     ),
     sourceGenerators in Compile += Def.task {
       val outDir = (sourceManaged in Compile).value / "scala" / "itac"

--- a/modules/main/src/main/scala/Editor.scala
+++ b/modules/main/src/main/scala/Editor.scala
@@ -18,7 +18,7 @@ class Editor[F[_]: Sync: Logger](edits: Map[String, SummaryEdit], log: Logger[F]
     edits.get(p.id) match {
       case Some(e) =>
 
-        log.warn(s"There are edits for ${p.id}/${file.getName}") *>
+        log.trace(s"There are edits for ${p.id}/${file.getName}") *>
         e.applyUpdate(p)
 
       case None    => log.trace(s"No edits for ${p.id}/${file.getName}")

--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -183,6 +183,12 @@ trait MainOpts { this: CommandIOApp =>
       header = "Export proposals."
     )((siteConfig, rolloverReport).mapN((sc, rr) => Export[IO](QueueEngine, sc, rr)))
 
+  lazy val scheduling: Command[Operation[IO]] =
+    Command(
+      name   = "scheduling",
+      header = "Scheduling report."
+    )((siteConfig, rolloverReport).mapN((sc, rr) => Scheduling[IO](QueueEngine, sc, rr)))
+
   lazy val gn: Opts[Site.GN.type] = Opts.flag(
     short = "n",
     long  = "north",
@@ -332,7 +338,8 @@ trait MainOpts { this: CommandIOApp =>
       summarize,
       duplicates,
       export,
-      splits
+      splits,
+      scheduling,
     ).sortBy(_.name).map(Opts.subcommand(_)).foldK
 
 }

--- a/modules/main/src/main/scala/operation/Scheduling.scala
+++ b/modules/main/src/main/scala/operation/Scheduling.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package itac
+package operation
+
+import org.davidmoten.text.utils.WordWrap
+import itac.util.Colors
+import edu.gemini.tac.qengine.p1.QueueBand
+import edu.gemini.tac.qengine.api.QueueEngine
+import java.nio.file.Path
+import io.chrisdavenport.log4cats.Logger
+import cats.effect.Blocker
+import cats._
+import cats.effect._
+import cats.implicits._
+
+object Scheduling {
+
+  def apply[F[_]: Sync: Parallel](
+    qe:             QueueEngine,
+    siteConfig:     Path,
+    rolloverReport: Option[Path]
+  ): Operation[F] =
+    new AbstractQueueOperation[F](qe, siteConfig, rolloverReport) {
+
+      def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] =
+        computeQueue(ws).flatMap { case (_, qc) =>
+          val qr = QueueResult(qc)
+          Sync[F].delay {
+            println(s"${Colors.BOLD}Scheduling Report for ${qc.context.site}-${qc.context.semester}.${Colors.RESET}")
+            QueueBand.values.foreach { qb =>
+              println(s"\n${Colors.BOLD}The following proposals were in Band ${qb.number} have scheduling notes.${Colors.RESET}\n")
+              val color =
+              qb.number match {
+                case 1 => Colors.YELLOW
+                case 2 => Colors.GREEN
+                case 3 => Colors.BLUE
+                case 4 => Colors.RED
+              }
+              for {
+                e  <- qr.entries(qb)
+                p  <- e.proposals.toList
+              } {
+                Option(p.p1proposal.scheduling).map(_.trim).filterNot(_.isEmpty()).foreach { s =>
+                  println(f"${color}${p.ntac.ranking.num.orEmpty}%5.1f ${p.id.reference}%-15s ${p.piName.orEmpty.take(20)}%-20s ${p.time.toHours.value}%5.1f h  ${e.programId}${Colors.RESET}")
+                  val newline = "\n        "
+                  val sʹ = WordWrap.from(s).maxWidth(80).newLine(newline).wrap()
+                  println(s"$newline$sʹ\n")
+                }
+              }
+            }
+            ExitCode.Success
+          }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
This adds an `itac scheduling` command, which takes the same arguments as `itac queue` but instead produces a report of all scheduling notes for programs in the queue.