### PR TITLE
use instrument name from visitor blueprint

### DIFF
--- a/modules/main/src/main/scala/BulkEditFile.scala
+++ b/modules/main/src/main/scala/BulkEditFile.scala
@@ -15,6 +15,7 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import scala.collection.JavaConverters._
 import cats.effect.Sync
+import edu.gemini.model.p1.immutable.VisitorBlueprint
 
 object BulkEditFile {
 
@@ -126,7 +127,12 @@ object BulkEditFile {
 
     def instruments(p: Proposal): String =
       (p.obsList ++ p.band3Observations)
-        .map { o => o.p1Observation.blueprint.fold("None")(_.name.takeWhile(_ != ' ')) }
+        .map { o =>
+          o.p1Observation.blueprint.foldMap {
+            case VisitorBlueprint(_, name) => name.trim
+            case b                         => b.name.takeWhile(_ != ' ')
+          }
+        }
         .distinct
         .sorted
         .mkString(", ")

--- a/modules/main/src/main/scala/operation/ChartData.scala
+++ b/modules/main/src/main/scala/operation/ChartData.scala
@@ -9,6 +9,7 @@ import cats.effect._
 import cats.implicits._
 import edu.gemini.tac.qengine.api.QueueEngine
 import edu.gemini.model.p1.immutable.TooTarget
+import edu.gemini.model.p1.immutable.VisitorBlueprint
 import io.chrisdavenport.log4cats.Logger
 import java.nio.file.Path
 import itac.util.Colors
@@ -38,8 +39,10 @@ object ChartData {
                 os.foldMap { o =>
                   val scaledTime = o.time.toHours.value * ratio
                   val hour       = o.p1Observation.target match { case Some(TooTarget(_, _)) => -1; case _ => o.target.ra.toHr.mag.toInt }
-                  val instrument = o.p1Observation.blueprint.foldMap(_.name.takeWhile(_ != ' ')) // muhahaha
-
+                  val instrument = o.p1Observation.blueprint.foldMap {
+                    case VisitorBlueprint(_, name) => name.trim
+                    case b                         => b.name.takeWhile(_ != ' ')
+                   }
                   Map((instrument, hour) -> scaledTime)
                 }
 


### PR DESCRIPTION
This updates `chart-data` and bulk edits generation to use the name from the blueprint if it's  visiting instrument.