### PR TITLE
add program id to duplication check

### DIFF
--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -336,7 +336,7 @@ trait MainOpts { this: CommandIOApp =>
     Command(
       name   = "duplicates",
       header = "Search for duplicate targets."
-    )(tolerance.map(Duplicates[IO](_)))
+    )((siteConfig, rolloverReport, tolerance).mapN((sc, rr, t) => Duplicates[IO](QueueEngine, sc, rr, t)))
 
   lazy val ops: Opts[Operation[IO]] =
     List(

--- a/modules/main/src/main/scala/operation/Duplicates.scala
+++ b/modules/main/src/main/scala/operation/Duplicates.scala
@@ -16,43 +16,59 @@ import gsp.math.HourAngle
 import gsp.math.Angle
 import edu.gemini.tac.qengine.p1.Proposal
 import itac.util.Colors
+import edu.gemini.tac.qengine.api.QueueEngine
+import java.nio.file.Path
+import itac.QueueResult
+import edu.gemini.tac.qengine.p1.QueueBand
+import edu.gemini.spModel.core.ProgramId
 
 object Duplicates {
 
-  def apply[F[_]: Sync: Parallel](tolerance: Angle): Operation[F] =
-    new Operation[F] {
+  def apply[F[_]: Sync: Parallel](
+    qe:             QueueEngine,
+    siteConfig:     Path,
+    rolloverReport: Option[Path],
+    tolerance:      Angle
+  ): Operation[F] =
+    new AbstractQueueOperation[F](qe, siteConfig, rolloverReport) {
 
-      def printTarget(key: TargetDuplicationChecker.ClusterKey)(member: TargetDuplicationChecker.ClusterMember): Unit = {
+      def printTarget(key: TargetDuplicationChecker.ClusterKey, pidMap: Map[String, ProgramId])(member: TargetDuplicationChecker.ClusterMember): Unit = {
         val target = member.target
         val ra     = HourAngle.HMS(Angle.hourAngle.get(Angle.fromDoubleDegrees(target.ra.mag))).format
         val dec    = Angle.DMS(Angle.fromDoubleDegrees(target.dec.mag)).format
-        println(f"${key.reference}%-15s  ${key.pi.lastName.take(15)}%-20s  ${member.instrument.take(20)}%-20s  $ra%16s $dec%16s  ${target.name.orEmpty.take(20)}%-20s")
+        println(f"${key.reference}%-15s  ${pidMap.get(key.reference).fold("--")(_.toString)}%-15s ${key.pi.lastName.take(15)}%-20s  ${member.instrument.take(20)}%-20s  $ra%16s $dec%16s  ${target.name.orEmpty.take(20)}%-20s")
       }
 
-      def checkForDuplicates(proposals: List[Proposal]): F[Unit] = {
+      def checkForDuplicates(proposals: List[Proposal], pidMap: Map[String, ProgramId]): F[Unit] = {
         val tdc  = new TargetDuplicationChecker(proposals, tolerance)
         val dups = tdc.allClusters
         Sync[F].delay {
             println()
             println(s"${Colors.BOLD}Target Duplication Report (tolerance ${Angle.fromStringDMS.reverseGet(tolerance)})${Colors.RESET}")
             println()
-            println(s"${Colors.BOLD}Reference        PI                    Blueprint              Coordinates                       Name${Colors.RESET}")
-                                  //CL-2020B-006     Kalari                Zorro Speckle (0.009   05:37:51.009999 290:50:26.100000  LMC_J053751.00-69093
+            println(s"${Colors.BOLD}Reference        Program ID      PI                    Blueprint              Coordinates                       Name${Colors.RESET}")
+                                  //US-2020B-154     GS-2020B-Q-220  Kim                   GMOS-S Longslit B600   20:50:18.088800 317:40:52.896000  Gaia DR2 66770775212
         } *> dups.traverse_{ ds =>
           Sync[F].delay {
             ds.foreach { case (p, nec) =>
-              nec.toList.foreach(printTarget(p))
+              nec.toList.foreach(printTarget(p, pidMap))
             }
             println()
           }
         }
       }
 
-      def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] = {
-        for {
-          ps <- ws.proposals
-          _  <- checkForDuplicates(ps)
-        } yield ExitCode.Success
+    def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] =
+      computeQueue(ws).flatMap { case (ps, qc) =>
+
+        val pidMap =
+          for {
+            b <- QueueBand.values
+            e <- QueueResult(qc).entries(b)
+            p <- e.proposals.toList
+          } yield (p.ntac.reference, e.programId)
+
+        checkForDuplicates(ps.filter(_.site == qc.context.site), pidMap.toMap).as(ExitCode.Success)
       }
 
   }


### PR DESCRIPTION
This adds the program ID to the target duplication report (`--` for proposals that are unsuccessful) to prevent unnecessary work when duplicates are found in proposals that don't make it into the queue.