### PR TITLE
export-related improvements

### DIFF
--- a/modules/engine/src/main/scala/p1/Proposal.scala
+++ b/modules/engine/src/main/scala/p1/Proposal.scala
@@ -16,6 +16,7 @@ import edu.gemini.model.p1.immutable.FastTurnaroundProgramClass
 import edu.gemini.model.p1.immutable.ClassicalProposalClass
 import edu.gemini.model.p1.immutable.QueueProposalClass
 import edu.gemini.model.p1.immutable.ProposalClass
+import java.io.File
 
 /**
  * The Proposal trait defines the information associated with a proposal for the purpose
@@ -91,6 +92,20 @@ sealed trait Proposal {
   def p1proposal: edu.gemini.model.p1.immutable.Proposal
   def p1mutableProposal: edu.gemini.model.p1.mutable.Proposal
 
+  def p1xmlFile: File
+
+  def p1pdfFile: File =
+    // p1xmlFile can be null because we need to retrofit old tests
+    Option(p1xmlFile).map { f =>
+      val name     = f.getName
+      val baseName =
+        name.lastIndexOf('.') match {
+          case -1 => name
+          case  n => name.substring(0, n)
+        }
+      new File(f.getParentFile, s"$baseName.pdf")
+    }.orNull
+
 }
 
 /**
@@ -109,7 +124,8 @@ case class CoreProposal(
   piName: Option[String] = None,
   piEmail: Option[String] = None,
   p1proposal: edu.gemini.model.p1.immutable.Proposal = null, // to avoid having to generate one for testcases that don't care
-  p1mutableProposal: edu.gemini.model.p1.mutable.Proposal = null // to avoid having to generate one for testcases that don't care
+  p1mutableProposal: edu.gemini.model.p1.mutable.Proposal = null, // to avoid having to generate one for testcases that don't care
+  p1xmlFile: File = null, // to avoid having to generate one for testcases that don't care
 ) extends Proposal {
   def core: CoreProposal = this
 }
@@ -155,6 +171,7 @@ case class JointProposalPart(
 
   def p1proposal = core.p1proposal
   def p1mutableProposal: edu.gemini.model.p1.mutable.Proposal = core.p1mutableProposal
+  def p1xmlFile = core.p1xmlFile
 
 }
 
@@ -218,6 +235,7 @@ case class JointProposal(jointIdValue: String, core: CoreProposal, ntacs: List[N
 
   def p1mutableProposal: edu.gemini.model.p1.mutable.Proposal = sys.error("should never get here, this class is to be removed")
 
+  def p1xmlFile: File = sys.error("should never get here, this class is to be removed")
 
 }
 

--- a/modules/engine/src/main/scala/p1/io/ProposalIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ProposalIo.scala
@@ -14,6 +14,7 @@ import edu.gemini.spModel.core.Site
 import edu.gemini.tac.qengine.util.Percent
 import edu.gemini.tac.qengine.util.Time
 import org.slf4j.LoggerFactory
+import java.io.File
 
 /**
   * Immutable Phase1 proposal
@@ -67,7 +68,8 @@ class ProposalIo(partners: Map[String, Partner]) {
       p: im.Proposal,
       mp: m.Proposal,
       when: Long,
-      jointIdGen: JointIdGen
+      jointIdGen: JointIdGen,
+      p1xml: File
   ): ValidationNel[String, (NonEmptyList[Proposal], JointIdGen)] = {
 
     def read(
@@ -184,7 +186,8 @@ class ProposalIo(partners: Map[String, Partner]) {
             piName(p),
             piEmail(p),
             p,
-            mp
+            mp,
+            p1xml
           )
 
           // If there are more ntacs, it is a Joint, otherwise just this core.

--- a/modules/engine/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalIoTest.scala
+++ b/modules/engine/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalIoTest.scala
@@ -92,7 +92,7 @@ class ProposalIoTest {
   @Test def testSingleProposal(): Unit = {
     val idGen = JointIdGen(0)
 
-    propIo.read((new ProposalFixture).proposal, null, when, idGen) match {
+    propIo.read((new ProposalFixture).proposal, null, when, idGen, null) match {
       case Success((NonEmptyList(prop, _), gen2)) =>
         assertEquals(1, gen2.next.count) // not advanced
         assertTrue(prop.piName.contains("Henderson"))
@@ -123,7 +123,7 @@ class ProposalIoTest {
         Left(List(ngoSubmission, sub2))
     }
 
-    propIo.read(p.proposal, null, when, idGen) match {
+    propIo.read(p.proposal, null, when, idGen, null) match {
       case Success((NonEmptyList(prop, _), gen2)) =>
         assertEquals(2, gen2.next.count)
         assertTrue(prop.jointId.contains("j0"))
@@ -153,7 +153,7 @@ class ProposalIoTest {
       override def observations = List(observation, nifsObservation)
     }
 
-    propIo.read(p.proposal, null, when, idGen) match {
+    propIo.read(p.proposal, null, when, idGen, null) match {
       case Success((NonEmptyList(prop0, prop1), gen2)) =>
         assertEquals(1, gen2.next.count)
         assertEquals(Set(Site.GN, Site.GS), Set(prop0.site, prop1.headOption.get.site))

--- a/modules/main/src/main/scala/QueueResult.scala
+++ b/modules/main/src/main/scala/QueueResult.scala
@@ -29,7 +29,7 @@ final case class QueueResult(queueCalc: QueueCalc) {
     val ps = queueCalc.queue.bandedQueue.getOrElse(qb, Nil)
     val gs = shuffle(groupJoints(ps))
     gs.zipWithIndex.map { case (nel, n) =>
-      Entry(nel, ProgramId.parse(s"${site.abbreviation}-${semester}-Q-${100 * qb.number + (n + 1)}"))
+      Entry(nel, ProgramId.parse(s"${site.abbreviation}-${semester}-${nel.head.mode.programId}-${100 * qb.number + (n + 1)}"))
     }
   }
 

--- a/modules/main/src/main/scala/SummaryEdit.scala
+++ b/modules/main/src/main/scala/SummaryEdit.scala
@@ -29,7 +29,7 @@ case class SummaryEdit(
     os.forEach { o =>
       val digest = ObservationDigest.digest(im.Observation(o))
       obsEdits.find(_.hash == digest) match {
-        case Some(e) => e.update(o, p)
+        case Some(e) => e.update(o, p, reference)
         case None => println(s"No digest for $o")
       }
     }

--- a/modules/main/src/main/scala/operation/Export.scala
+++ b/modules/main/src/main/scala/operation/Export.scala
@@ -67,8 +67,10 @@ object Export {
                   dropNullKeys = true,
                   // mappingStyle = Printer.FlowStyle.Block
                 )
-                println(s"${pr.pretty(SummaryDebugJson.EncoderProposal(p))}\n-----------------------\n")
 
+                println(s"[An] input file is ${e.proposals.head.p1xmlFile.getName} and the PDF file is ${e.proposals.head.p1pdfFile.getName}.")
+
+                println(s"${pr.pretty(SummaryDebugJson.EncoderProposal(p))}\n-----------------------\n")
 
               }
 


### PR DESCRIPTION
This does a few things in preparation for proposal export:
- We can now determine what the PDF file for a given engine-model `Proposal` should be.
- We now log when an edit clobbers a `TooTarget` or `NonSiderealTarget` because these may need to be fixed in the ODB.
- Program IDs now reflect the proper mode (`Q`, `LP`, or `C`).