### PR TITLE
match ToO targets properly when applying edits

### DIFF
--- a/modules/main/src/main/scala/SummaryObsEdit.scala
+++ b/modules/main/src/main/scala/SummaryObsEdit.scala
@@ -103,8 +103,8 @@ case class SummaryObsEdit(
 
         case _: NonSiderealTarget =>
 
-          // We never match a NonSiderealTarget. Always replace with a sidereal target if there
-          // is any edit to the observation.
+          // We never match a NonSiderealTarget. Always replace with a sidereal target if it is
+          // mentioned in the edits file.
           false
 
       }


### PR DESCRIPTION
ToO targets were always being replaced if they were mentioned in the edits file. This change ensures that a ToO target will not be clobbered unless the edits file changes the name or coordinates (in which case it will be replaced with a sidereal target as before).