### PR TITLE
gen-emails

### DIFF
--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -222,9 +222,9 @@ trait MainOpts { this: CommandIOApp =>
       header = "Export proposals to the specified ODB. You can re-run this if necessary (programs will be replaced)."
     )((siteConfig, rolloverReport, host, port, progids).mapN(Export[IO](QueueEngine, _, _, _, _, _)))
 
-  lazy val email: Command[Operation[IO]] =
+  lazy val emailGen: Command[Operation[IO]] =
     Command(
-      name   = "email",
+      name   = "gen-emails",
       header = "Create PI emails for successful proposals."
     )((siteConfig, rolloverReport, progids).mapN(Email[IO](QueueEngine, _, _, _)))
 
@@ -386,7 +386,7 @@ trait MainOpts { this: CommandIOApp =>
 
   lazy val ops: Opts[Operation[IO]] =
     List(
-      email,
+      emailGen,
       placeholder("skeleton"),
       init,
       ls,

--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -222,6 +222,12 @@ trait MainOpts { this: CommandIOApp =>
       header = "Export proposals to the specified ODB. You can re-run this if necessary (programs will be replaced)."
     )((siteConfig, rolloverReport, host, port, progids).mapN(Export[IO](QueueEngine, _, _, _, _, _)))
 
+  lazy val email: Command[Operation[IO]] =
+    Command(
+      name   = "email",
+      header = "Create PI emails for successful proposals."
+    )((siteConfig, rolloverReport, progids).mapN(Email[IO](QueueEngine, _, _, _)))
+
   lazy val bulkEdits: Command[Operation[IO]] =
     Command(
       name = "bulk-edits",
@@ -290,12 +296,6 @@ trait MainOpts { this: CommandIOApp =>
       name = name,
       header = s"Placeholder for $name, which is not yet implemented."
     )(Placeholder.pure[Opts])
-
-  lazy val email: Command[Operation[IO]] =
-    Command(
-      name   = "email",
-      header = "Generate queue emails."
-    )((siteConfig, rolloverReport).mapN((sc, rr) => Email[IO](QueueEngine, sc, rr)))
 
   lazy val reference: Opts[String] =
     Opts.argument[String]("semester")

--- a/modules/main/src/main/scala/PrimaryNgo.scala
+++ b/modules/main/src/main/scala/PrimaryNgo.scala
@@ -68,7 +68,7 @@ object PrimaryNgo {
            "US"                       |
            "UNITED STATES OF AMERICA" => Some(Info(NgoPartner.US, None))
       case s =>
-        LoggerFactory.getLogger("edu.gemini.itac").warn(s"No NGO partner for ${s}.")
+        LoggerFactory.getLogger("edu.gemini.itac").debug(s"No NGO partner for ${s}.")
         None
     }
 

--- a/modules/main/src/main/scala/Workspace.scala
+++ b/modules/main/src/main/scala/Workspace.scala
@@ -316,7 +316,7 @@ object Workspace {
           } yield p
 
         def progIdHash: F[ProgIdHash] =
-          new ProgIdHash("x").pure[F]
+          commonConfig.map(c => new ProgIdHash(c.emailConfig.hashKey))
 
       }
     }

--- a/modules/main/src/main/scala/config/Common.scala
+++ b/modules/main/src/main/scala/config/Common.scala
@@ -79,6 +79,7 @@ object Common {
     deadline: LocalDate,
     instructionsURL: String,
     eavesdroppingURL: String,
+    hashKey: String
   )
   object EmailConfig {
     implicit val encoderEmailConfig: Encoder[EmailConfig] = deriveEncoder

--- a/modules/main/src/main/scala/config/Common.scala
+++ b/modules/main/src/main/scala/config/Common.scala
@@ -11,13 +11,15 @@ import java.{util => ju}
 import java.time.LocalDate
 import edu.gemini.tac.qengine.api.config.ConditionsBin
 import edu.gemini.tac.qengine.api.config.ConditionsBinGroup
+import itac.config.Common.EmailConfig
 
 final case class Common(
   semester: Semester,
   shutdown: PerSite[List[LocalDateRange]],
   partners: Partner => PartnerConfig,
   sequence: PerSite[List[Partner]],
-  conditionsBins: List[ConditionsBin[Percent]]
+  conditionsBins: List[ConditionsBin[Percent]],
+  emailConfig: EmailConfig
 ) { self =>
 
   object engine {
@@ -72,5 +74,15 @@ object Common {
 
   implicit val encoderCommon: Encoder[Common] = deriveEncoder
   implicit val decoderCommon: Decoder[Common] = deriveDecoder
+
+  case class EmailConfig(
+    deadline: LocalDate,
+    instructionsURL: String,
+    eavesdroppingURL: String,
+  )
+  object EmailConfig {
+    implicit val encoderEmailConfig: Encoder[EmailConfig] = deriveEncoder
+    implicit val decoderEmailConfig: Decoder[EmailConfig] = deriveDecoder
+  }
 
 }

--- a/modules/main/src/main/scala/operation/AbstractExportOperation.scala
+++ b/modules/main/src/main/scala/operation/AbstractExportOperation.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package itac.operation
+
+import itac._
+import java.io.File
+import edu.gemini.spModel.core.ProgramId
+import edu.gemini.tac.qengine.p1.Mode
+import edu.gemini.tac.qengine.p1.Proposal
+import edu.gemini.model.p1.mutable.TimeUnit
+import edu.gemini.model.p1.mutable.TimeAmount
+import edu.gemini.tac.qengine.p1.QueueBand
+import cats.effect._
+import cats.implicits._
+import edu.gemini.tac.qengine.api.QueueEngine
+import io.chrisdavenport.log4cats.Logger
+import java.nio.file.Path
+import itac.PrimaryNgo.Info
+import cats.data.NonEmptyList
+
+abstract class AbstractExportOperation[F[_]: Sync](
+  qe:             QueueEngine,
+  siteConfig:     Path,
+  rolloverReport: Option[Path]
+) extends AbstractQueueOperation[F](qe, siteConfig, rolloverReport) {
+
+      def export(p: edu.gemini.model.p1.mutable.Proposal, pdfFile: File, pid: ProgramId): Unit
+
+      def doExport(ps: List[Proposal], qr: QueueResult, bes: Map[String, BulkEdit], cwd: Path): F[ExitCode] =
+        Sync[F].delay {
+
+          def addItacNode(p: Proposal, pid: ProgramId, band: QueueBand): Unit =
+            bes.get(p.ntac.reference) match {
+              case Some(be) => be.unsafeApplyUpdate(p.p1mutableProposal, itac.BulkEdit.Accept(pid, band.number, {
+                val ta = new TimeAmount
+                ta.setUnits(TimeUnit.HR)
+                ta.setValue(new java.math.BigDecimal(p.time.toHours.value))
+                ta
+              }))
+              case None =>
+                // This should never happen because we update the bulk-edit file every run
+                sys.error(s"Proposal ${p.ntac.reference} is not present in the bulk edits file. Cannot create ITAC node.")
+            }
+
+          QueueBand.values.foreach { qb =>
+
+              // Non-Queue Proposals ...
+              val nonQueue =
+                ps.filter(_.site == qr.queueCalc.context.site)                // are at this site
+                  .filterNot(p => qr.queueCalc.proposalLog.proposalIds(p.id)) // but don't appear in the log
+
+              // Pick out classicals and those that shouldn't be here
+              val (classical, orphans) = nonQueue.partition(_.mode == Mode.Classical)
+
+              // These *should* all be classical. Let's be sure though.
+              if (orphans.nonEmpty) {
+                orphans.foreach { p =>
+                  println(s"${p.ntac.reference} is ${p.mode} and is not in the queue!")
+                }
+                throw new ItacException("Non-classical program somehow escaped the queue!")
+              }
+
+              def pdfFile(name: String): File =
+                cwd.resolve(s"pdfs/$name").toAbsolutePath.toFile
+
+              // Get classical *entries* and then add them.
+              qr.classical(classical).foreach { e =>
+                val p = e.proposals.head // don't handle joints yet, may not matter
+                addItacNode(p, e.programId, QueueBand.QBand1)
+                export(p.p1mutableProposal, pdfFile(p.p1pdfFile), e.programId)
+              }
+
+              // Queue Proposals
+              qr.entries(qb).foreach { e =>
+
+                // Add ITAC Accept nodes to each proposal in this queue entry.
+                e.proposals.toList.foreach(addItacNode(_, e.programId, qb))
+
+                // Move the one with the primary NGO to the head. We merge everything into it.
+                val parts = PrimaryNgo.find(e.proposals.head.p1mutableProposal) match {
+                  case None => e.proposals // hope for the best
+                  case Some(Info(p, _)) =>
+                    val (a, b) = e.proposals.toList.partition(_.ntac.partner.id == p.name)
+                    // println(s"primary ngo is $p, part ngos are ${e.proposals.toList.map(_.ntac.partner.id)} ... ${a.length} + ${b.length}")
+                    NonEmptyList.fromList(a ++ b).getOrElse(sys.error("unpossible!"))
+                }
+
+                 // Merge joints.
+                val p = Merge.merge(parts.map(_.p1mutableProposal))
+
+                // debug print the proposal
+                // println("─" * 100)
+                // println(s"[An] input file is ${e.proposals.head.p1xmlFile.getName} and the PDF file is ${e.proposals.head.p1pdfFile.getName}.")
+                // println(SummaryDebug.summary(p))
+
+                export(p, pdfFile(e.proposals.head.p1pdfFile), e.programId)
+
+              }
+
+            }
+
+            // Workbooks for NGOs
+
+            ExitCode.Success
+          }
+
+      def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] =
+        for {
+          p   <- computeQueue(ws); (ps, qc) = p
+          be  <- ws.bulkEdits(ps)
+          cwd <- ws.cwd
+          e   <- doExport(ps, QueueResult(qc), be, cwd)
+        } yield e
+
+  }

--- a/modules/main/src/main/scala/operation/Email.scala
+++ b/modules/main/src/main/scala/operation/Email.scala
@@ -24,6 +24,7 @@ import edu.gemini.model.p1.mutable.NgoPartner.CL
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import org.davidmoten.text.utils.WordWrap
+import itac.config.Common
 
 object Email {
 
@@ -59,7 +60,7 @@ object Email {
   ): Operation[F] =
     new AbstractExportOperation[F](qe, siteConfig, rolloverReport) {
 
-      def export(p: Proposal, pdfFile: File, pid: ProgramId): Unit = {
+      def export(p: Proposal, pdfFile: File, pid: ProgramId, cc: Common): Unit = {
 
         // If we gave an explicit list of progids, make sure pid is in it
         if (progids.nonEmpty && !progids.contains(pid))
@@ -70,8 +71,8 @@ object Email {
 
         val (sub, body) =
           emailSubjectAndBody(
-            deadline =            LocalDate.ofYearDay(2020, 175),
-            instructionsUrl =     "http://www.gemini.edu/node/21275",
+            deadline =            cc.emailConfig.deadline,
+            instructionsUrl =     cc.emailConfig.instructionsURL,
             semester =            p.getSemester,
             progTitle =           p.getTitle,
             piName =              p.getInvestigators.getPi,
@@ -84,7 +85,7 @@ object Email {
             ntacSupportEmail =    Option(p.getItacAccept.getEmail).getOrElse("(none)"),
             geminiContactEmail =  Option(p.getItacAccept.getContact).getOrElse("(none)"),
             progKey =             "TODO",
-            eavesdroppingLink =   "TODO",
+            eavesdroppingLink =   cc.emailConfig.eavesdroppingURL,
             itacComments =        Option(p.getItac.getComment).getOrElse("(none)"),
           )
 
@@ -111,7 +112,7 @@ object Email {
   implicit val ShowSemester:   Show[Semester]   = s => s"${s.getYear}${s.getHalf}"
   implicit val ShowTimeAmount: Show[TimeAmount] = ta => s"${ta.getValue.setScale(1, RoundingMode.HALF_UP)} ${ta.getUnits.name.toLowerCase}"
   implicit val ShowPrincipalInvestigator: Show[PrincipalInvestigator] = pi => s"${pi.getFirstName} ${pi.getLastName}"
-  implicit val ShowLocalDate:   Show[LocalDate]   = DateTimeFormatter.ofPattern("MMM dd YYYY").format(_).toUpperCase
+  implicit val ShowLocalDate:   Show[LocalDate]   = DateTimeFormatter.ofPattern("MMM d YYYY").format(_).toUpperCase
 
   def emailSubjectAndBody(
     deadline:           LocalDate,

--- a/modules/main/src/main/scala/operation/Export.scala
+++ b/modules/main/src/main/scala/operation/Export.scala
@@ -16,6 +16,7 @@ import edu.gemini.model.p1.mutable.ObjectFactory
 import java.io.ByteArrayOutputStream
 import java.io.ByteArrayInputStream
 import edu.gemini.model.p1.mutable.Proposal
+import itac.config.Common
 
 object Export {
 
@@ -35,7 +36,7 @@ object Export {
   ): Operation[F] =
     new AbstractExportOperation[F](qe, siteConfig, rolloverReport) {
 
-      def export(p: Proposal, pdfFile: File, pid: ProgramId): Unit = {
+      def export(p: Proposal, pdfFile: File, pid: ProgramId, cc: Common): Unit = {
 
         // If we gave an explicit list of progids, make sure pid is in it
         if (progids.nonEmpty && !progids.contains(pid))

--- a/modules/main/src/main/scala/operation/Export.scala
+++ b/modules/main/src/main/scala/operation/Export.scala
@@ -6,24 +6,16 @@ package itac.operation
 import itac._
 import java.io.File
 import edu.gemini.spModel.core.ProgramId
-import edu.gemini.tac.qengine.p1.Mode
-import edu.gemini.tac.qengine.p1.Proposal
-import edu.gemini.model.p1.mutable.TimeUnit
-import edu.gemini.model.p1.mutable.TimeAmount
-import edu.gemini.tac.qengine.p1.QueueBand
 import cats._
 import cats.effect._
-import cats.implicits._
 import edu.gemini.tac.qengine.api.QueueEngine
-import io.chrisdavenport.log4cats.Logger
 import java.nio.file.Path
 import sttp.client._
 import javax.xml.bind.{ JAXBContext, Marshaller }
 import edu.gemini.model.p1.mutable.ObjectFactory
 import java.io.ByteArrayOutputStream
 import java.io.ByteArrayInputStream
-import itac.PrimaryNgo.Info
-import cats.data.NonEmptyList
+import edu.gemini.model.p1.mutable.Proposal
 
 object Export {
 
@@ -33,10 +25,6 @@ object Export {
   private lazy val marshaller: Marshaller =
     context.createMarshaller
 
-  /**
-    * @param siteConfig path to site-specific configuration file, which can be absolute or relative
-    *   (in which case it will be resolved relative to the workspace directory).
-    */
   def apply[F[_]: Sync: Parallel](
     qe:             QueueEngine,
     siteConfig:     Path,
@@ -45,131 +33,43 @@ object Export {
     odbPort:        Int,
     progids:        List[ProgramId]
   ): Operation[F] =
-    new AbstractQueueOperation[F](qe, siteConfig, rolloverReport) {
+    new AbstractExportOperation[F](qe, siteConfig, rolloverReport) {
 
-      def doExport(ps: List[Proposal], qr: QueueResult, bes: Map[String, BulkEdit], cwd: Path): F[ExitCode] =
-        Sync[F].delay {
+      def export(p: Proposal, pdfFile: File, pid: ProgramId): Unit = {
 
-          def addItacNode(p: Proposal, pid: ProgramId, band: QueueBand): Unit =
-            bes.get(p.ntac.reference) match {
-              case Some(be) => be.unsafeApplyUpdate(p.p1mutableProposal, itac.BulkEdit.Accept(pid, band.number, {
-                val ta = new TimeAmount
-                ta.setUnits(TimeUnit.HR)
-                ta.setValue(new java.math.BigDecimal(p.time.toHours.value))
-                ta
-              }))
-              case None =>
-                // This should never happen because we update the bulk-edit file every run
-                sys.error(s"Proposal ${p.ntac.reference} is not present in the bulk edits file. Cannot create ITAC node.")
-            }
+        // If we gave an explicit list of progids, make sure pid is in it
+        if (progids.nonEmpty && !progids.contains(pid))
+          return; //
 
-          def export(p: edu.gemini.model.p1.mutable.Proposal, pdfFile: File, pid: ProgramId): Unit = {
+        println(s"==> exporting <#${System.identityHashCode(p).toHexString}> ${pid} with ${pdfFile.getName} ... ")
 
-            // If we gave an explicit list of progids, make sure pid is in it
-            if (progids.nonEmpty && !progids.contains(pid))
-              return; //
+        // Serialize the proposal to XML.
+        val baos = new ByteArrayOutputStream
+        marshaller.marshal(p, baos)
+        baos.flush()
+        val xmlStream = new ByteArrayInputStream(baos.toByteArray)
 
-            println(s"==> exporting <#${System.identityHashCode(p).toHexString}> ${pid} with ${pdfFile.getName} ... ")
+        // Skip if no PDF file
+        if (!pdfFile.exists()) {
+          println(s"${Console.RED}    NO PDF FILE!${Console.RESET}")
+          return
+        }
 
-            // Serialize the proposal to XML.
-            val baos = new ByteArrayOutputStream
-            marshaller.marshal(p, baos)
-            baos.flush()
-            val xmlStream = new ByteArrayInputStream(baos.toByteArray)
+        // ok need an http client here that can do multipart
+        implicit val backend = HttpURLConnectionBackend()
+        val req = basicRequest.multipartBody(
+          multipart("proposal", xmlStream).contentType("text/xml"),
+          multipartFile("attachment", pdfFile).contentType("application/pdf")
+        ).get(uri"http://$odbHost:$odbPort/skeleton?convert=true")
 
-            // Skip if no PDF file
-            if (!pdfFile.exists()) {
-              println(s"${Console.RED}    NO PDF FILE!${Console.RESET}")
-              return
-            }
+        val res = req.send()
 
-            // ok need an http client here that can do multipart
-            implicit val backend = HttpURLConnectionBackend()
-            val req = basicRequest.multipartBody(
-              multipart("proposal", xmlStream).contentType("text/xml"),
-              multipartFile("attachment", pdfFile).contentType("application/pdf")
-            ).get(uri"http://$odbHost:$odbPort/skeleton?convert=true")
+        println(res.code.code)
+        if (res.code.code >= 300)
+          println(res.body)
 
-            val res = req.send()
+      }
 
-            println(res.code.code)
-            if (res.code.code >= 300)
-              println(res.body)
-
-          }
-
-          QueueBand.values.foreach { qb =>
-
-              // Non-Queue Proposals ...
-              val nonQueue =
-                ps.filter(_.site == qr.queueCalc.context.site)                // are at this site
-                  .filterNot(p => qr.queueCalc.proposalLog.proposalIds(p.id)) // but don't appear in the log
-
-              // Pick out classicals and those that shouldn't be here
-              val (classical, orphans) = nonQueue.partition(_.mode == Mode.Classical)
-
-              // These *should* all be classical. Let's be sure though.
-              if (orphans.nonEmpty) {
-                orphans.foreach { p =>
-                  println(s"${p.ntac.reference} is ${p.mode} and is not in the queue!")
-                }
-                throw new ItacException("Non-classical program somehow escaped the queue!")
-              }
-
-              def pdfFile(name: String): File =
-                cwd.resolve(s"pdfs/$name").toAbsolutePath.toFile
-
-              // Get classical *entries* and then add them.
-              qr.classical(classical).foreach { e =>
-                val p = e.proposals.head // don't handle joints yet, may not matter
-                addItacNode(p, e.programId, QueueBand.QBand1)
-                export(p.p1mutableProposal, pdfFile(p.p1pdfFile), e.programId)
-              }
-
-              // Queue Proposals
-              qr.entries(qb).foreach { e =>
-
-                // Add ITAC Accept nodes to each proposal in this queue entry.
-                e.proposals.toList.foreach(addItacNode(_, e.programId, qb))
-
-                // Move the one with the primary NGO to the head. We merge everything into it.
-                val parts = PrimaryNgo.find(e.proposals.head.p1mutableProposal) match {
-                  case None => e.proposals // hope for the best
-                  case Some(Info(p, _)) =>
-                    val (a, b) = e.proposals.toList.partition(_.ntac.partner.id == p.name)
-                    // println(s"primary ngo is $p, part ngos are ${e.proposals.toList.map(_.ntac.partner.id)} ... ${a.length} + ${b.length}")
-                    NonEmptyList.fromList(a ++ b).getOrElse(sys.error("unpossible!"))
-                }
-
-                 // Merge joints.
-                val p = Merge.merge(parts.map(_.p1mutableProposal))
-
-                // debug print the proposal
-                // println("─" * 100)
-                // println(s"[An] input file is ${e.proposals.head.p1xmlFile.getName} and the PDF file is ${e.proposals.head.p1pdfFile.getName}.")
-                // println(SummaryDebug.summary(p))
-
-                export(p, pdfFile(e.proposals.head.p1pdfFile), e.programId)
-
-              }
-
-            }
-
-            // Workbooks for NGOs
-
-            ExitCode.Success
-          }
-
-      def run(ws: Workspace[F], log: Logger[F], b: Blocker): F[ExitCode] =
-        for {
-          p   <- computeQueue(ws); (ps, qc) = p
-          be  <- ws.bulkEdits(ps)
-          cwd <- ws.cwd
-          e   <- doExport(ps, QueueResult(qc), be, cwd)
-        } yield e
-
-  }
+    }
 
 }
-
-

--- a/modules/main/src/main/scala/operation/Export.scala
+++ b/modules/main/src/main/scala/operation/Export.scala
@@ -17,6 +17,7 @@ import java.io.ByteArrayOutputStream
 import java.io.ByteArrayInputStream
 import edu.gemini.model.p1.mutable.Proposal
 import itac.config.Common
+import edu.gemini.util.security.auth.ProgIdHash
 
 object Export {
 
@@ -36,7 +37,7 @@ object Export {
   ): Operation[F] =
     new AbstractExportOperation[F](qe, siteConfig, rolloverReport) {
 
-      def export(p: Proposal, pdfFile: File, pid: ProgramId, cc: Common): Unit = {
+      def export(p: Proposal, pdfFile: File, pid: ProgramId, cc: Common, pih: ProgIdHash): Unit = {
 
         // If we gave an explicit list of progids, make sure pid is in it
         if (progids.nonEmpty && !progids.contains(pid))

--- a/modules/main/src/main/scala/operation/ProgramPartnerTimeMutable.scala
+++ b/modules/main/src/main/scala/operation/ProgramPartnerTimeMutable.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package itac.operation
+
+import cats._
+import cats.implicits._
+import edu.gemini.model.p1.mutable._
+import edu.gemini.model.p1.mutable.TimeUnit._
+import java.math.BigDecimal
+import scala.collection.JavaConverters._
+import java.math.MathContext
+
+object ProgramPartnerTimeMutable {
+  import Email.ProposalOps
+
+  private val HrPerNight = new BigDecimal(10)
+
+  private implicit val MonoidTimeAmount: Monoid[TimeAmount] =
+    new Monoid[TimeAmount] {
+      def combine(x: TimeAmount, y: TimeAmount): TimeAmount = {
+        val (t, u) = (x.getUnits, y.getUnits) match {
+          case (HR, HR)       => (x.getValue.add(y.getValue), HR)
+          case (NIGHT, NIGHT) => (x.getValue.add(y.getValue), NIGHT)
+          case (HR, NIGHT)    => (x.getValue.add(y.getValue.multiply(HrPerNight)), HR)
+          case (NIGHT, HR)    => (x.getValue.multiply(HrPerNight).add(y.getValue), HR)
+        }
+        val ta = new TimeAmount
+        ta.setUnits(u)
+        ta.setValue(t)
+        ta
+      }
+      val empty: TimeAmount = {
+        val ta = new TimeAmount
+        ta.setUnits(HR)
+        ta.setValue(BigDecimal.ZERO)
+        ta
+      }
+    }
+
+  implicit class TimeAmountOps(ta: TimeAmount) {
+
+    def toHours: TimeAmount =
+      ta.getUnits match {
+        case HR    => ta
+        case NIGHT =>
+          val taʹ = new TimeAmount
+          taʹ.setUnits(HR)
+          taʹ.setValue(ta.getValue.multiply(HrPerNight))
+          taʹ
+      }
+
+    def scale(factor: BigDecimal): TimeAmount = {
+      val taʹ = new TimeAmount
+      taʹ.setUnits(ta.getUnits)
+      taʹ.setValue(ta.getValue.multiply(factor))
+      taʹ
+    }
+
+  }
+
+  def programAndPartnerTime(p: Proposal): (TimeAmount, TimeAmount) = {
+
+    // Need our band
+    val band: Band =
+      p.getItacAccept.getBand match {
+        case 3 => Band.BAND_3
+        case _ => Band.BAND_1_2
+      }
+
+    // Original estimated times from the proposal
+    val (progTime, partTime) =
+      p.getObservations.getObservation.asScala.toList
+        .filter(_.getBand == band)
+        .foldMap(o => (o.getProgTime, o.getPartTime))
+
+    // Factor with respect to the awarded time
+    val ratio: BigDecimal = progTime.toHours.getValue.divide((progTime |+| partTime).toHours.getValue, MathContext.DECIMAL32)
+
+    // Scale the prog and program time
+    val progTimeʹ = p.getItacAccept.getAward.scale(ratio)
+    val partTimeʹ = p.getItacAccept.getAward.scale(BigDecimal.ONE.subtract(ratio))
+
+    // Done
+    (progTimeʹ, partTimeʹ)
+
+  }
+
+}


### PR DESCRIPTION
This adds `itac gen-emails --north` which generates PI emails into workspace folder `emails/`.

This requires changes to `common.yaml`:

```yaml
emailConfig:
  deadline: 2020-07-20
  instructionsURL: http://www.gemini.edu/observing/phase-ii/instructions
  eavesdroppingURL: http://unknown
  hashKey: xxxx
```

Where `hashKey` is the same value as the `edu.gemini.spModel.gemini.obscomp.key` property in OCS.
