### PR TITLE
remove ntac comment

### DIFF
--- a/modules/engine/src/main/scala/p1/Ntac.scala
+++ b/modules/engine/src/main/scala/p1/Ntac.scala
@@ -12,7 +12,6 @@ case class Ntac(partner: Partner,
   awardedTime: Time,
   poorWeather: Boolean,
   lead: Option[String] = None,
-  comment: Option[String] = None,
   submission: Submission = null,
   undividedTime: Option[Time] = None, // this will be set to the original time if the actual time is reduced due to a site split
   ngoEmail: Option[String] = None

--- a/modules/engine/src/main/scala/p1/io/NtacIo.scala
+++ b/modules/engine/src/main/scala/p1/io/NtacIo.scala
@@ -43,7 +43,7 @@ object NtacIo {
     }
 
   private def mkNtac(lead: Option[String], submission: im.Submission)(p: Partner)(response: Option[Response]): Option[Ntac] =
-    response.map { r => Ntac(p, r.ref, r.rank, r.awardedTime, r.poorWeather, lead, response.flatMap(_.comment), submission, None, response.flatMap(_.ngoEmail)) }
+    response.map { r => Ntac(p, r.ref, r.rank, r.awardedTime, r.poorWeather, lead, submission, None, response.flatMap(_.ngoEmail)) }
 
   private val NoneAccepted = NONE_ACCEPTED.failureNel[NonEmptyList[Ntac]]
 

--- a/modules/main/src/main/scala/BulkEdit.scala
+++ b/modules/main/src/main/scala/BulkEdit.scala
@@ -12,7 +12,6 @@ import itac.BulkEdit.Reject
 final case class BulkEdit(
   ngoEmail:      Option[String],
   staffEmail:    Option[String],
-  ntacComment:   Option[String],
   itacComment:   Option[String]
 ) {
   import BulkEdit.Disposition
@@ -47,7 +46,6 @@ final case class BulkEdit(
   private def update(sr: SubmissionResponse): Unit =
     if (sr != null) {
       update(sr.getAccept())
-      ntacComment.foreach(sr.setComment)
     }
 
   private def update(ns: NgoSubmission): Unit =

--- a/modules/main/src/main/scala/BulkEditFile.scala
+++ b/modules/main/src/main/scala/BulkEditFile.scala
@@ -26,8 +26,7 @@ object BulkEditFile {
     val Pi            = 3
     val NgoEmail      = 4
     val StaffEmail    = 5
-    val NtacComment   = 6
-    val ItacComment   = 7
+    val ItacComment   = 6
   }
 
   def createOrUpdate[F[_]: Sync](file: File, ps: List[Proposal]): F[Unit] =
@@ -52,9 +51,8 @@ object BulkEditFile {
         val ref         = r.getCell(Reference).getStringCellValue()
         val ngoEmail    = r.getCell(NgoEmail).safeGetStringCellValue
         val staffEmail  = r.getCell(StaffEmail).safeGetStringCellValue
-        val ntacComment = r.getCell(NtacComment).safeGetStringCellValue
         val itacComment = r.getCell(ItacComment).safeGetStringCellValue
-        ref -> BulkEdit(ngoEmail, staffEmail, ntacComment, itacComment)
+        ref -> BulkEdit(ngoEmail, staffEmail, itacComment)
       } .toMap
     }
 
@@ -84,7 +82,6 @@ object BulkEditFile {
         sh.setColumnWidth(Pi,            256 * 20)
         sh.setColumnWidth(NgoEmail,      256 * 20)
         sh.setColumnWidth(StaffEmail,    256 * 20)
-        sh.setColumnWidth(NtacComment,   256 * 64)
         sh.setColumnWidth(ItacComment,   256 * 64)
         sh.createFreezePane(3, 1, 3, 1);
         sh.setZoom(120)
@@ -120,7 +117,6 @@ object BulkEditFile {
       create(Pi,            "PI")
       create(NgoEmail,      "NGO Email")
       create(StaffEmail,    "Staff Email")
-      create(NtacComment,   "NTAC Comment")
       create(ItacComment,   "ITAC Comment")
 
     }
@@ -145,7 +141,6 @@ object BulkEditFile {
       newR.createCell(Instrument   ).setCellValue(instruments(p))
       newR.createCell(NgoEmail     ).setCellValue(p.ntac.ngoEmail.orEmpty)
       newR.createCell(StaffEmail   ).setBlank()
-      newR.createCell(NtacComment  ).setCellValue(p.ntac.comment.orEmpty)
       newR.createCell(ItacComment  ).setBlank()
     }
 


### PR DESCRIPTION
This removes the NTAC comment from the ITAC model and bulk-edit spreadsheet. We don't use it.