### PR TITLE
move itac comments from bulk_edit.xls to <ref>.yaml

### DIFF
--- a/modules/engine/src/main/scala/p1/Proposal.scala
+++ b/modules/engine/src/main/scala/p1/Proposal.scala
@@ -21,6 +21,7 @@ case class Proposal(
   p1proposal: edu.gemini.model.p1.immutable.Proposal = null, // to avoid having to generate one for testcases that don't care
   p1mutableProposal: edu.gemini.model.p1.mutable.Proposal = null, // to avoid having to generate one for testcases that don't care
   p1xmlFile: File = null, // to avoid having to generate one for testcases that don't care
+  itacComment: Option[String] = None,
 ) {
 
   lazy val id: Proposal.Id = Proposal.Id(ntac.partner, ntac.reference)

--- a/modules/engine/src/main/scala/p1/io/ProposalIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ProposalIo.scala
@@ -185,6 +185,10 @@ class ProposalIo {
           val b12 = bandList(ObservationIo.BandChoice.Band124)
           val b3 = bandList(ObservationIo.BandChoice.Band3)
 
+          // Get the itacComment, if any.
+          val itacComment: Option[String] =
+            p.proposalClass.itac.flatMap(_.comment)
+
           // done
           Proposal(
             ntacʹ,
@@ -198,7 +202,8 @@ class ProposalIo {
             piEmail(p),
             p,
             mp,
-            p1xml
+            p1xml,
+            itacComment
           )
 
       }

--- a/modules/main/src/main/scala/BulkEdit.scala
+++ b/modules/main/src/main/scala/BulkEdit.scala
@@ -12,12 +12,10 @@ import itac.BulkEdit.Reject
 final case class BulkEdit(
   ngoEmail:      Option[String],
   staffEmail:    Option[String],
-  itacComment:   Option[String]
 ) {
   import BulkEdit.Disposition
 
-  private def update(itac: Itac, disp: Disposition, too: TooOption): Unit = {
-    itacComment.foreach(itac.setComment)
+  private def update(itac: Itac, disp: Disposition, too: TooOption): Unit =
     disp match {
 
       case Accept(pid, band, award) =>
@@ -35,8 +33,6 @@ final case class BulkEdit(
         itac.setAccept(null)
         itac.setReject(new ItacReject)
     }
-
-  }
 
   private def update(sa: SubmissionAccept): Unit =
     if (sa != null) {

--- a/modules/main/src/main/scala/BulkEditFile.scala
+++ b/modules/main/src/main/scala/BulkEditFile.scala
@@ -26,7 +26,6 @@ object BulkEditFile {
     val Pi            = 3
     val NgoEmail      = 4
     val StaffEmail    = 5
-    val ItacComment   = 6
   }
 
   def createOrUpdate[F[_]: Sync](file: File, ps: List[Proposal]): F[Unit] =
@@ -51,8 +50,7 @@ object BulkEditFile {
         val ref         = r.getCell(Reference).getStringCellValue()
         val ngoEmail    = r.getCell(NgoEmail).safeGetStringCellValue
         val staffEmail  = r.getCell(StaffEmail).safeGetStringCellValue
-        val itacComment = r.getCell(ItacComment).safeGetStringCellValue
-        ref -> BulkEdit(ngoEmail, staffEmail, itacComment)
+        ref -> BulkEdit(ngoEmail, staffEmail)
       } .toMap
     }
 
@@ -82,7 +80,6 @@ object BulkEditFile {
         sh.setColumnWidth(Pi,            256 * 20)
         sh.setColumnWidth(NgoEmail,      256 * 20)
         sh.setColumnWidth(StaffEmail,    256 * 20)
-        sh.setColumnWidth(ItacComment,   256 * 64)
         sh.createFreezePane(3, 1, 3, 1);
         sh.setZoom(120)
         wb.write(file)
@@ -115,9 +112,8 @@ object BulkEditFile {
       create(Site,          "Site")
       create(Instrument,    "Instrument")
       create(Pi,            "PI")
-      create(NgoEmail,      "NGO Email")
-      create(StaffEmail,    "Staff Email")
-      create(ItacComment,   "ITAC Comment")
+      create(NgoEmail,      "Principal Support")
+      create(StaffEmail,    "Additional Support")
 
     }
 
@@ -141,7 +137,6 @@ object BulkEditFile {
       newR.createCell(Instrument   ).setCellValue(instruments(p))
       newR.createCell(NgoEmail     ).setCellValue(p.ntac.ngoEmail.orEmpty)
       newR.createCell(StaffEmail   ).setBlank()
-      newR.createCell(ItacComment  ).setBlank()
     }
 
     def updateSheet(sh: Sheet, ps: List[Proposal]): Unit = {

--- a/modules/main/src/main/scala/Summary.scala
+++ b/modules/main/src/main/scala/Summary.scala
@@ -33,6 +33,7 @@ case class Summary(slices: OneOrTwo[Proposal]) {
   val award     = slices.fst.ntac.awardedTime
   val rank      = slices.fst.ntac.ranking.num.orEmpty
   val too       = slices.fst.too
+  val comment   = slices.fst.itacComment
 
   def yaml(disable: Option[Site])(implicit ev: Ordering[BandedObservation]) =
     f"""|
@@ -43,6 +44,7 @@ case class Summary(slices: OneOrTwo[Proposal]) {
         |Award:     ${award.toHours.value}%1.1f
         |Rank:      ${rank}%1.1f
         |ToO:       ${too}
+        |Comment:   ${comment.orEmpty}
         |
         |Observations:
         |${siteSummaries.foldMap(_.yaml(disable))}

--- a/modules/main/src/main/scala/operation/NgoSpreadsheet.scala
+++ b/modules/main/src/main/scala/operation/NgoSpreadsheet.scala
@@ -218,7 +218,7 @@ object NgoSpreadsheet {
       addCell(Time, 0.0)
       addCell(ProgTime, 0.0)
       addCell(PartTime, 0.0)
-      addCell(ItacComment, "")
+      addCell(ItacComment, p.itacComment.orEmpty)
       addCell(Title, p.p1proposal.title)
       n += 1
 

--- a/modules/main/src/main/scala/operation/NgoSpreadsheet.scala
+++ b/modules/main/src/main/scala/operation/NgoSpreadsheet.scala
@@ -67,8 +67,7 @@ object NgoSpreadsheet {
           // TODO: include removed proposals
           p   <- computeQueue(ws)
           (ps, qc) = p
-          bes <- ws.bulkEdits(ps)
-          _   <- wbs.traverse { case (p, wb) => Sync[F].delay(writeSheet(wb, p, bes, ps, QueueResult(qc))) }
+          _   <- wbs.traverse { case (p, wb) => Sync[F].delay(writeSheet(wb, p, ps, QueueResult(qc))) }
         } yield ExitCode.Success
     }
 
@@ -84,7 +83,7 @@ object NgoSpreadsheet {
   val ItacComment =  9 // ITAC Feedback: @ITAC_COMMENTS@
   val Title       = 10 // Program Title: @PROG_TITLE@
 
-  def writeSheet(wb: Workbook, p: Partner, bes: Map[String, BulkEdit], ps: List[Proposal], qr: QueueResult): Unit = {
+  def writeSheet(wb: Workbook, p: Partner, ps: List[Proposal], qr: QueueResult): Unit = {
     val sh = wb.createSheet(qr.context.site.displayName)
 
     // A bold font!
@@ -176,7 +175,7 @@ object NgoSpreadsheet {
         addCell(Time, (e.proposals.foldMap(_.time)).toHours.value)
         addCell(ProgTime, progTime.toHours.value)
         addCell(PartTime, partTime.toHours.value)
-        addCell(ItacComment, bes.get(p.ntac.reference).flatMap(_.itacComment).orEmpty)
+        addCell(ItacComment, p.itacComment.orEmpty)
         addCell(Title, p.p1proposal.title)
         n += 1
 

--- a/modules/main/src/main/scala/operation/Summarize.scala
+++ b/modules/main/src/main/scala/operation/Summarize.scala
@@ -79,16 +79,17 @@ object Summarize {
         val header =
           s"""|# Edit file for ${summary.reference}
               |# You may edit [only] the following fields/columns.
-              |# - Award as Decimal Hours
-              |# - Rank  as Decimal
-              |# - Band  as B1/2, B3
-              |# - CC    as ${CloudCover.values.mkString(", ")}
-              |# - IQ    as ${ImageQuality.values.mkString(", ")}
-              |# - SB    as ${SkyBackground.values.mkString(", ")}
-              |# - WV    as ${WaterVapor.values.mkString(", ")}
-              |# - RA    as HMS
-              |# - Dec   as Signed DMS(signed dms)
-              |# - Name  as Text, set to DISABLE to disable observation
+              |# - Award    as Decimal Hours
+              |# - Rank     as Decimal
+              |# - Comment  as Text
+              |# - Band     as B1/2, B3
+              |# - CC       as ${CloudCover.values.mkString(", ")}
+              |# - IQ       as ${ImageQuality.values.mkString(", ")}
+              |# - SB       as ${SkyBackground.values.mkString(", ")}
+              |# - WV       as ${WaterVapor.values.mkString(", ")}
+              |# - RA       as HMS
+              |# - Dec      as Signed DMS(signed dms)
+              |# - Name     as Text, set to DISABLE to disable observation
               |""".stripMargin
 
         if (edit) {


### PR DESCRIPTION
This moves ITAC comments from the bulk edit spreadsheet to the individual summary edit files. It also fixes an issue where ITAC comments weren't showing up in the NGO spreadsheet for failed proposals.