### PR TITLE
add filter arg to readAll, use it when reading edits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v2
-      - uses: olafurpg/setup-gpg@v2
-      - name: Publish
-        run: sbt ci-release
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v10
+      - uses: coursier/cache-action@v3
+      - uses: olafurpg/setup-gpg@v3
+      - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -5,17 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v2
-      - name: Cache Coursier
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/coursier
-          key: sbt-coursier-cache
-      - name: Cache SBT
-        uses: actions/cache@v1
-        with:
-          path: ~/.sbt
-          key: sbt-${{ hashFiles('**/build.sbt') }}
-      - name: Compile and run tests
-        run: sbt clean main/headerCheck compile test
+      - uses: olafurpg/setup-scala@v10
+      - uses: coursier/cache-action@v3
+      - run: sbt clean main/headerCheck compile test

--- a/modules/main/src/main/scala/Workspace.scala
+++ b/modules/main/src/main/scala/Workspace.scala
@@ -168,8 +168,8 @@ object Workspace {
               .toList
           }
 
-        def readAll[A: Decoder](path: Path): F[List[A]] =
-          listFiles(path).flatMap(_.traverse(readData[A]))
+        def readAll[A: Decoder](path: Path, suffix: String): F[List[A]] =
+          listFiles(path).flatMap(_.filter(_.toFile.getName.endsWith(suffix)).traverse(readData[A]))
 
         def writeText(path: Path, text: String): F[Path] = {
           val p = dir.resolve(path)
@@ -220,7 +220,7 @@ object Workspace {
           }
 
         def edits: F[Map[String, SummaryEdit]] =
-          readAll[SummaryEdit](EditsDir).map(_.map(e => (e.reference -> e)).toMap)
+          readAll[SummaryEdit](EditsDir, ".yaml").map(_.map(e => (e.reference -> e)).toMap)
 
         def bulkEdits(ps: List[Proposal]): F[Map[String, BulkEdit]] =
           for {


### PR DESCRIPTION
This fixes the issue of `.DS_Store` files messing stuff up in the `edits/` folder. We now only consider files ending in `.yaml`.