### PR TITLE
add dry-run flag for mailer

### DIFF
--- a/modules/main/src/main/scala/Main.scala
+++ b/modules/main/src/main/scala/Main.scala
@@ -394,7 +394,7 @@ trait MainOpts { this: CommandIOApp =>
     Command(
       name   = "send-emails",
       header = "Sends all emails in the emails/ folder."
-    )(EmailSend[IO].pure[Opts])
+    )(Opts.flag("dry-run", "Test, but don't actually send emails.", "n").orFalse.map(EmailSend[IO](_)))
 
   lazy val duplicates: Command[Operation[IO]] =
     Command(


### PR DESCRIPTION
`itac send-emails` will now prompt to continue, or pretend to send emails if `-n` is passed