### PR TITLE
[REL-3950] fix nonsidereal coordinate edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ marie-old
 marie-old2
 sanity-check.sh
 test-ws
+itac-software_jun9
+*.out

--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,9 @@ lazy val engine = project
   .settings(
     name := "itac-engine",
     libraryDependencies ++= Seq(
-      "edu.gemini.ocs"          %% "edu-gemini-model-p1"         % "2021001.1.1",
-      "edu.gemini.ocs"          %% "edu-gemini-shared-skyobject" % "2020001.1.7",
-      "edu.gemini.ocs"          %% "edu-gemini-util-skycalc"     % "2020001.1.7",
+      "edu.gemini.ocs"          %% "edu-gemini-model-p1"         % "2022001.1.2",
+      "edu.gemini.ocs"          %% "edu-gemini-shared-skyobject" % "2021101.1.2",
+      "edu.gemini.ocs"          %% "edu-gemini-util-skycalc"     % "2021101.1.2",
       "org.scala-lang.modules"  %% "scala-xml"                   % "2.0.0-M2",
       "org.slf4j"                % "slf4j-api"                   % "1.7.30",
       "javax.xml.bind"           % "jaxb-api"                    % "2.3.1",

--- a/modules/engine/src/main/scala/p1/io/ObservationIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ObservationIo.scala
@@ -87,7 +87,10 @@ object ObservationIo {
     o.target.map(target(_, when)).fold(MISSING_TARGET.failureNel[Target]) { _.successNel[String] }
 
   def target(t: im.Target, when: Long): Target = {
-    val c = t.coords(when) | tooCoords
+    // If it's a nonsidereal target we want to use the reference coordinates, if any, otherwise use
+    // the ephemeris as normal.
+    val rc = Option(t).collect { case nst: im.NonSiderealTarget => nst.referenceCoordinates } .flatten
+    val c  = rc orElse t.coords(when) getOrElse tooCoords
     Target(c.ra.toAngle.toDegrees, c.dec.toDegrees, ~Option(t.name))
   }
 

--- a/modules/engine/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalFixture.scala
+++ b/modules/engine/src/test/scala/edu/gemini/tac/qengine/p1/io/ProposalFixture.scala
@@ -16,8 +16,7 @@ class ProposalFixture {
   def semester      = im.Semester(2014, im.SemesterOption.A)
   def title         = "Test Proposal"
   def abs           = "My test proposal abstract"
-  def tacCategory   = Some(im.TacCategory.STARS_AND_STELLAR_EVOLUTION)
-  def keywords      = List(m.Keyword.BLUE_STRAGGLERS)
+  def tacCategory   = Some(im.TacCategory.ACTIVE_GALAXIES_QUASARS_SMBH)
 
   def piStatus      = im.InvestigatorStatus.PH_D
   def piAddress     = im.InstitutionAddress("Bovine University")
@@ -92,7 +91,6 @@ class ProposalFixture {
     abs,
     "scheduling",
     tacCategory,
-    keywords,
     investigators,
     targets,
     observations,

--- a/modules/main/src/main/scala/Editor.scala
+++ b/modules/main/src/main/scala/Editor.scala
@@ -9,19 +9,26 @@ import edu.gemini.model.p1.mutable.Proposal
 import edu.gemini.model.p1.{ immutable => im }
 import io.chrisdavenport.log4cats.Logger
 import java.io.File
+import edu.gemini.spModel.core
 
 /** Proposal editing. This applies edits that are supplied as part of the configuration. */
 class Editor[F[_]: Sync: Logger](edits: Map[String, SummaryEdit], log: Logger[F]) {
   import EditorOps._
 
-  def applyEdits(file: File, p: Proposal): F[Unit] =
+  /**
+   * Apply edits in `file` to mutable proposal `p`, yielding a map from mutable model target id
+   * to reference coordinates, if any. These become populated in the *immutable* proposal that we
+   * use to construct our ITAC model.
+   */
+  def applyEdits(file: File, p: Proposal): F[Map[String, core.Coordinates]] =
     p.id.flatMap(edits.get) match {
       case Some(e) =>
 
         log.debug(s"There are edits for ${p.id}/${file.getName}") *>
         e.applyUpdate(p)
 
-      case None    => log.debug(s"No edits for ${p.id}/${file.getName}")
+      case None    =>
+        log.debug(s"No edits for ${p.id}/${file.getName}").as(Map.empty)
 
     }
 

--- a/modules/main/src/main/scala/ObservationDigest.scala
+++ b/modules/main/src/main/scala/ObservationDigest.scala
@@ -61,7 +61,7 @@ object ObservationDigest {
       // N.B. ignore the UUID, which is assigned by the deserializer
       case TooTarget(_, n)                       => (n).hash
       case SiderealTarget(_, n, cs, e, pm, mags) => (n, cs, e, pm, mags).hash
-      case NonSiderealTarget(_, n, eph, e)       => (n, eph, e).hash
+      case NonSiderealTarget(_, n, eph, e, _, _, _)   => (n, eph, e).hash
     }
 
   implicit val HashAltair: Hash[Altair] =
@@ -136,7 +136,7 @@ object ObservationDigest {
     ("00000000" + o.hash.toHexString).takeRight(8)
 
   def digest(o: M.Observation): String =
-    digest(Observation(o))
+    digest(Observation(o, None))
 
 
 }

--- a/modules/main/src/main/scala/ProposalLoader.scala
+++ b/modules/main/src/main/scala/ProposalLoader.scala
@@ -65,11 +65,11 @@ object ProposalLoader {
           context.createUnmarshaller.unmarshal(f).asInstanceOf[M.Proposal]
         } .flatTap(mutator(f, _))
           .flatMap { p =>
-          editor.applyEdits(f, p).flatMap { _ =>
+          editor.applyEdits(f, p).flatMap { referenceCoords =>
             Sync[F].delay {
               // important to delay here! any time you look at a mutable value it's a side-effect!
               // see https://github.com/gemini-hlsw/itac/pull/29 :-(
-              val pʹ = edu.gemini.model.p1.immutable.Proposal(p)
+              val pʹ = edu.gemini.model.p1.immutable.Proposal(p, referenceCoords)
               (pʹ.copy(observations = pʹ.nonEmptyObservations), p)
             }
           }

--- a/modules/main/src/main/scala/SummaryObsEdit.scala
+++ b/modules/main/src/main/scala/SummaryObsEdit.scala
@@ -138,6 +138,8 @@ case class SummaryObsEdit(
                 val t2 = new NonSiderealTarget()
                 t2.setEpoch(t.getEpoch())
                 t2.getEphemeris().addAll(t.getEphemeris)
+                t2.setHorizonsDesignation(t.getHorizonsDesignation())
+                t2.setHorizonsQuery(t.getHorizonsQuery())
                 t2
 
           }

--- a/modules/main/src/main/scala/SummaryObsEdit.scala
+++ b/modules/main/src/main/scala/SummaryObsEdit.scala
@@ -10,7 +10,7 @@ import gsp.math.Declination
 import edu.gemini.tac.qengine.{ p1 => itac }
 import io.circe.Decoder
 import scala.jdk.CollectionConverters._
-import org.slf4j.LoggerFactory
+import edu.gemini.spModel.core
 
 /**
  * Used by `SummaryEdit` to deal with observations, which is where most of the complications lie.
@@ -73,9 +73,10 @@ case class SummaryObsEdit(
   }
 
   /*
-   * The logic here is the same as in updateConditions above. We never change a value in-place.
+   * The logic here is the same as in updateConditions above. We never change a value in-place. If
+   * the target is nonsidereal we return its ID and the new reference coordinates.
    */
-  def updateTarget(o: Observation, p: Proposal, ref: String): Unit = {
+  def updateTarget(o: Observation, p: Proposal, ref: String): Option[(String, core.Coordinates)] = {
 
     val allTargets = p.getTargets().getSiderealOrNonsiderealOrToo().asScala
 
@@ -118,19 +119,29 @@ case class SummaryObsEdit(
         case None =>
 
           // Warn in the case where we're clobbering something that's not a SiderealTarget
-          o.getTarget match {
-            case _: SiderealTarget => () // ok
-            case _: TooTarget | _: NonSiderealTarget =>
-              LoggerFactory.getLogger("edu.gemini.itac").warn(s"$ref: replacing ${o.getTarget.getClass.getSimpleName} '${o.getTarget.getName}' with a sidereal target.")
+          val t2: Target =
+            o.getTarget match {
+              case _: SiderealTarget =>
+                val t2 = new SiderealTarget()
+                t2.setDegDeg {
+                  val dd = new DegDegCoordinates
+                  dd.setRa(BigDecimal(ra.toAngle.toDoubleDegrees).bigDecimal)
+                  dd.setDec(BigDecimal(dec.toAngle.toSignedDoubleDegrees).bigDecimal)
+                  dd
+                }
+                t2
+
+              case _: TooTarget =>
+                new TooTarget()
+
+              case t: NonSiderealTarget =>
+                val t2 = new NonSiderealTarget()
+                t2.setEpoch(t.getEpoch())
+                t2.getEphemeris().addAll(t.getEphemeris)
+                t2
+
           }
 
-          val t2 = new SiderealTarget()
-          t2.setDegDeg {
-            val dd = new DegDegCoordinates
-            dd.setRa(BigDecimal(ra.toAngle.toDoubleDegrees).bigDecimal)
-            dd.setDec(BigDecimal(dec.toAngle.toSignedDoubleDegrees).bigDecimal)
-            dd
-          }
           t2.setName(name)
           t2.setId(s"target-${allTargets.map(_.getId.dropWhile(!_.isDigit).toInt).max + 1}")
           // no magnitudes or proper motion, we have no idea
@@ -140,13 +151,23 @@ case class SummaryObsEdit(
 
     o.setTarget(replaceWith)
 
+    replaceWith match {
+      case  _: NonSiderealTarget =>
+        val coords = core.Coordinates.fromDegrees(ra.toAngle.toDoubleDegrees, dec.toAngle.toSignedDoubleDegrees).getOrElse(sys.error(s"Invalid coordinates specified for $ref"))
+        Some(replaceWith.getId() -> coords)
+      case _ =>
+        None
+    }
+
   }
 
-  // Appy this edit to the specified observation.
-  def update(o: Observation, p: Proposal, ref: String): Unit =
-    if (o != null) {
+  // Appy this edit to the specified observation, returning a possibly empty mapping from
+  // nonsidereal target ids to reference coordinates.
+  def update(o: Observation, p: Proposal, ref: String): Option[(String, core.Coordinates)] =
+    Option(o).flatMap { o =>
       if (name == "DISABLE") {
         o.setEnabled(false)
+        None
       } else {
         o.setBand(band)
         updateCondition(o, p)


### PR DESCRIPTION
This PR is built on top of https://github.com/gemini-hlsw/ocs/pull/1893 (which added the notion of reference coordinates to the P1 immutable model's `NonSiderealTarget`) and allows edits to nonsidereal targets as follows:

- If the coordinates are edited, the new values will be used as a reference position _only for the purposes of bin-filling_. The original ephemeris is unaltered and will be exported to the ODB as-id.
- If you wish to change the ephemeris or replace the target entirely you need to use the PIT.

I verified this by observing that:

- The queue output from this version and the current binary distribution of `itac` are identical, so edits are being observed for bin-filling.
- Exported programs from current `itac` replace edited nonsidereal targets with sidereal ones, but the working version with these changes does not.
