### PR TITLE
Add support for MAROON-X

### DIFF
--- a/modules/engine/src/main/scala/p1/io/ObservationIo.scala
+++ b/modules/engine/src/main/scala/p1/io/ObservationIo.scala
@@ -40,6 +40,7 @@ object ObservationIo {
         case d: im.DssiBlueprint       => d.site
         case a: im.AlopekeBlueprint    => a.site
         case z: im.ZorroBlueprint      => z.site
+        case m: im.MaroonXBlueprint    => m.site
         case t: im.TexesBlueprint      => t.site
         case p: im.PhoenixBlueprint    => p.site
         case v: im.VisitorBlueprint    => v.site

--- a/modules/main/src/main/scala/BulkEdit.scala
+++ b/modules/main/src/main/scala/BulkEdit.scala
@@ -177,6 +177,7 @@ final case class BulkEdit(
           // Alopeke, Zorro, IGRINS, GRACES, MAROON-X.
           case _: AlopekeBlueprint => true
           case _: ZorroBlueprint   => true
+          case _: MaroonXBlueprint => true
           case _: IgrinsBlueprint  => true
           case _: GracesBlueprint  => true
           case _: VisitorBlueprint => true

--- a/modules/main/src/main/scala/MergeBlueprint.scala
+++ b/modules/main/src/main/scala/MergeBlueprint.scala
@@ -59,6 +59,7 @@ trait MergeBlueprint {
       case c: VisitorBlueprintChoice    => unNull(c.getVisitor)
       case c: AlopekeBlueprintChoice    => unNull(c.getAlopeke)
       case c: ZorroBlueprintChoice      => unNull(c.getZorro)
+      case c: MaroonXBlueprintChoice    => unNull(c.getMaroonX)
       case c => sys.error(s"MergeBlueprint.allBlueprints: unhandled class ${c.getClass.getName}")
     }
 
@@ -205,6 +206,9 @@ trait MergeBlueprint {
   val canonicalizeZorroBlueprint: Canonicalizer[ZorroBlueprint] =
     canonicalizeBlueprintBase[ZorroBlueprint, ZorroBlueprintChoice](_ setZorro _)
 
+  val canonicalizeMaroonXBlueprint: Canonicalizer[MaroonXBlueprint] =
+    canonicalizeBlueprintBase[MaroonXBlueprint, MaroonXBlueprintChoice](_ setMaroonX _)
+
   /**
    * Find or destructively create matching `BlueprintBase` in `into`.
    */
@@ -248,6 +252,7 @@ trait MergeBlueprint {
       case bp: TrecsBlueprintSpectroscopy => canonicalizeTrecsBlueprintSpectroscopy(bp, into)
       case bp: VisitorBlueprint => canonicalizeVisitorBlueprint(bp, into)
       case bp: ZorroBlueprint => canonicalizeZorroBlueprint(bp, into)
+      case bp: MaroonXBlueprint => canonicalizeMaroonXBlueprint(bp, into)
       case _ => (into, sys.error("blah") : BlueprintBase)._2
     }
 

--- a/modules/main/src/main/scala/MergeBlueprintInstances.scala
+++ b/modules/main/src/main/scala/MergeBlueprintInstances.scala
@@ -142,5 +142,8 @@ object MergeBlueprintInstances {
   implicit val EqZorroBlueprint: Eq[ZorroBlueprint] =
     Eq.by(b => (b.getMode()))
 
+  implicit val EqMaroonXBlueprint: Eq[MaroonXBlueprint] =
+    Eq.allEqual
+
 
 }

--- a/modules/main/src/main/scala/ObservationDigest.scala
+++ b/modules/main/src/main/scala/ObservationDigest.scala
@@ -111,6 +111,7 @@ object ObservationDigest {
       case b: TrecsBlueprintImaging         => (b.name, b.filters).hash
       case b: TrecsBlueprintSpectroscopy    => (b.name, b.disperser, b.fpu).hash
       case b: ZorroBlueprint                => (b.name, b.mode).hash
+      case b: MaroonXBlueprint              => (b.name).hash
       case b: SubaruBlueprint               => (b.name, b.customName, b.instrument).hash
       case b: KeckBlueprint                 => (b.name, b.instrument).hash
       case b: VisitorBlueprint              => (b.name, b.customName, b.site).hash

--- a/modules/main/src/main/scala/operation/InstrumentScientistSpreadsheet.scala
+++ b/modules/main/src/main/scala/operation/InstrumentScientistSpreadsheet.scala
@@ -89,9 +89,10 @@ object InstrumentScientistSpreadsheet {
     case object Trecs      extends Instrument
     case object Visitor    extends Instrument
     case object Zorro      extends Instrument
+    case object MaroonX    extends Instrument
 
     val all: List[Instrument] =
-      List(Alopeke, Dssi, Flamingos2, GmosN, GmosS, Gnirs, Gpi, Graces, Gsaoi, Igrins, Keck, Michelle, Nici, Nifs, Niri, Phoenix, Subaru, Texes, Trecs, Visitor, Zorro)
+      List(Alopeke, Dssi, Flamingos2, GmosN, GmosS, Gnirs, Gpi, Graces, Gsaoi, Igrins, Keck, Michelle, Nici, Nifs, Niri, Phoenix, Subaru, Texes, Trecs, Visitor, Zorro, MaroonX)
 
     def forBlueprint(b: BlueprintBase): Instrument =
       b match {
@@ -132,6 +133,7 @@ object InstrumentScientistSpreadsheet {
         case _: TrecsBlueprintSpectroscopy    => Trecs
         case _: VisitorBlueprint              => Visitor
         case _: ZorroBlueprint                => Zorro
+        case _: MaroonXBlueprint              => MaroonX
       }
 
   }
@@ -190,6 +192,7 @@ object InstrumentScientistSpreadsheet {
       case b: TrecsBlueprintSpectroscopy    => Props(Mode -> "Spectroscopy", FPU -> b.getFpu, Disperser -> b.getDisperser)
       case b: VisitorBlueprint              => Props(Site -> b.getSite, InstrumentSelection -> b.getCustomName)
       case b: ZorroBlueprint                => Props(Mode -> b.getMode)
+      case _: MaroonXBlueprint              => Props()
     }
   }
 


### PR DESCRIPTION
This adds support for MAROON-X by mirroring what we did with ZORRO (actually IGRINS would have been a better choice because like MAROON-X it has no configuration properties). In any case I just searched for `Zorro` and made sure there was a corresponding `MaroonX` case.

Verified that a prior proposal with a `Vistor` blueprint and custom name `MAROON-X` works the same with the new `MaroonX` blueprint.