### PR TITLE
25B fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ itac-software_jun9
 nov18
 20220520_sandysdir
 test2
+itac_WD

--- a/modules/main/src/main/scala/operation/AbstractExportOperation.scala
+++ b/modules/main/src/main/scala/operation/AbstractExportOperation.scala
@@ -50,8 +50,8 @@ abstract class AbstractExportOperation[F[_]: Sync](
             ps.filter(_.site == qr.context.site)                // are at this site
               .filterNot(p => qr.proposalLog.proposalIds(p.id)) // but don't appear in the log
 
-          // Pick out classicals and those that shouldn't be here
-          val (classical, orphans) = nonQueue.partition(_.mode == Mode.Classical)
+          // Pick out those that shouldn't be here
+          val orphans = nonQueue.filterNot(_.mode == Mode.Classical)
 
           // These *should* all be classical. Let's be sure though.
           if (orphans.nonEmpty) {
@@ -63,13 +63,6 @@ abstract class AbstractExportOperation[F[_]: Sync](
 
           def pdfFile(name: String): File =
             cwd.resolve(s"pdfs/$name").toAbsolutePath.toFile
-
-          // Get classical *entries* and then add them.
-          qr.classical(classical).foreach { e =>
-            val p = e.proposals.head // don't handle joints yet, may not matter
-            addItacNode(p, e.programId, QueueBand.QBand1)
-            export(p.p1mutableProposal, p.p1pdfs.map(pdfFile), e.programId, cc, pih)
-          }
 
           QueueBand.values.foreach { qb =>
 
@@ -96,6 +89,7 @@ abstract class AbstractExportOperation[F[_]: Sync](
               // println(s"[An] input file is ${e.proposals.head.p1xmlFile.getName} and the PDF file is ${e.proposals.head.p1pdfFile.getName}.")
               // println(SummaryDebug.summary(p))
 
+              // println(s"QUEUE: export(${e.proposals.toList.map(_.id)}, ..., ${e.programId}, ..., ...)")
               export(p, e.proposals.head.p1pdfs.map(pdfFile), e.programId, cc, pih)
 
             }

--- a/modules/main/src/main/scala/operation/AbstractExportOperation.scala
+++ b/modules/main/src/main/scala/operation/AbstractExportOperation.scala
@@ -89,7 +89,6 @@ abstract class AbstractExportOperation[F[_]: Sync](
               // println(s"[An] input file is ${e.proposals.head.p1xmlFile.getName} and the PDF file is ${e.proposals.head.p1pdfFile.getName}.")
               // println(SummaryDebug.summary(p))
 
-              // println(s"QUEUE: export(${e.proposals.toList.map(_.id)}, ..., ${e.programId}, ..., ...)")
               export(p, e.proposals.head.p1pdfs.map(pdfFile), e.programId, cc, pih)
 
             }

--- a/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
+++ b/modules/main/src/main/scala/util/TargetDuplicationChecker.scala
@@ -14,6 +14,7 @@ import cats.data.NonEmptyChain
 import edu.gemini.model.p1.immutable.Investigator
 import edu.gemini.model.p1.immutable.BlueprintBase
 import edu.gemini.model.p1.immutable.VisitorBlueprint
+import edu.gemini.model.p1.immutable.Igrins2Blueprint
 
 /**
  *
@@ -93,6 +94,9 @@ class TargetDuplicationChecker(proposals: List[Proposal], val tolerance: Angle =
     // blueprint for MAROON-X and IGRINS (and who knows what else in the future?)
     def blueprintName(bb: BlueprintBase): String =
       bb match {
+        case i: Igrins2Blueprint => 
+          // the default toString includes the telluric count, which doesn't matter here :-\
+          s"IGRINS-2 ${i.nodding.value}"
         case v: VisitorBlueprint =>
           v.customName match {
             case "IGRINS - continuous observation" => "IGRINS"


### PR DESCRIPTION
This fixes two issues:

- Classical proposals were being exported twice, which as a side effect was causing duplicate program ids. It's probably due to classicals having special handling in the past, but now they're in the Band1 queue at export time and the special handling isn't needed anymore.
- We're using the blueprint toString as a stand-in for distinct configurations and IGRINS2's toString includes the number of tellurics, which I believe isn't relevant for duplication checking. So I hacked around that.